### PR TITLE
fix(security): remove "owner" from platform super-admin roles (#7)

### DIFF
--- a/backend/src/MechanicBuddy.Management.Api/Authorization/SuperAdminAuthHandler.cs
+++ b/backend/src/MechanicBuddy.Management.Api/Authorization/SuperAdminAuthHandler.cs
@@ -9,7 +9,12 @@ public class SuperAdminRequirement : IAuthorizationRequirement
 
 public class SuperAdminAuthHandler : AuthorizationHandler<SuperAdminRequirement>
 {
-    private static readonly string[] AllowedRoles = { "admin", "support", "owner" };
+    // Platform super-admin roles ONLY. "owner" (tenant owners created via the
+    // public, unauthenticated /api/signup endpoint) MUST NOT appear here: doing
+    // so let anyone self-register and obtain full control-plane access
+    // (provision/deprovision/delete tenants, run migrations, impersonate tenants).
+    // Tenant owners are authorized only for owner-facing [Authorize] endpoints.
+    private static readonly string[] AllowedRoles = { "admin", "support" };
 
     protected override Task HandleRequirementAsync(
         AuthorizationHandlerContext context,


### PR DESCRIPTION
## Summary
Closes #7 — **CRITICAL**: unauthenticated control-plane takeover.

`POST /api/signup` is public and creates a user with role `"owner"`, returning a signed JWT. Because `SuperAdminAuthHandler.AllowedRoles` included `"owner"`, that token satisfied the `SuperAdminOnly` policy — granting anonymous attackers full control-plane access (provision/deprovision/delete tenants, run migrations, impersonate any tenant).

## Change
- `SuperAdminAuthHandler.AllowedRoles`: `{ "admin", "support", "owner" }` → `{ "admin", "support" }`, with a comment documenting why `"owner"` must never be re-added.

Platform staff (`admin`/`support`, created only via the already-`SuperAdminOnly` `SuperAdminController`) keep control-plane access. Tenant owners keep their owner-facing surface (Dashboard, Billing, Domains, MyDomains, Tenant list/get) which is plain `[Authorize]`.

## Verification
- `dotnet build -c Release` succeeds (0 errors; warnings pre-existing).

## Follow-up (separate issue)
Several `TenantsController` endpoints (`GetAll`, `Create`, `Update`, `Suspend`, `Resume`) are plain `[Authorize]` and thus reachable by tenant owners — broken access control to be tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)