### PR TITLE
fix(security): harden management API auth (#9)

### DIFF
--- a/backend/src/MechanicBuddy.Management.Api/Program.cs
+++ b/backend/src/MechanicBuddy.Management.Api/Program.cs
@@ -64,7 +64,7 @@ builder.Services.AddAuthentication(options =>
 })
 .AddJwtBearer(options =>
 {
-    options.RequireHttpsMetadata = false; // Set to true in production
+    options.RequireHttpsMetadata = !builder.Environment.IsDevelopment(); // HTTPS required outside Development
     options.SaveToken = true;
     options.TokenValidationParameters = new TokenValidationParameters
     {

--- a/backend/src/MechanicBuddy.Management.Api/Services/SuperAdminService.cs
+++ b/backend/src/MechanicBuddy.Management.Api/Services/SuperAdminService.cs
@@ -301,19 +301,29 @@ public class SuperAdminService
 
     private string GenerateRequestSignature(object requestBody)
     {
-        // In production, use HMAC-SHA256 with a shared secret
+        // HMAC-SHA256 over the request body. The shared secret MUST be configured
+        // out-of-band; never fall back to a hard-coded default — a known signing
+        // key lets an attacker forge X-SuperAdmin-Signature and log into any tenant.
+        var sharedSecret = Environment.GetEnvironmentVariable("SUPER_ADMIN_SHARED_SECRET");
+        if (string.IsNullOrWhiteSpace(sharedSecret))
+        {
+            throw new InvalidOperationException(
+                "SUPER_ADMIN_SHARED_SECRET is not configured; refusing to sign cross-tenant access requests.");
+        }
+
         var json = JsonSerializer.Serialize(requestBody);
-        using var hmac = new System.Security.Cryptography.HMACSHA256(
-            Encoding.UTF8.GetBytes(Environment.GetEnvironmentVariable("SUPER_ADMIN_SHARED_SECRET") ?? "dev-secret"));
+        using var hmac = new System.Security.Cryptography.HMACSHA256(Encoding.UTF8.GetBytes(sharedSecret));
         var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(json));
         return Convert.ToBase64String(hash);
     }
 
     private string GenerateOneTimeAccessToken(int adminId, string tenantId)
     {
-        var tokenData = $"{adminId}:{tenantId}:{DateTime.UtcNow.Ticks}:{Guid.NewGuid()}";
-        var bytes = Encoding.UTF8.GetBytes(tokenData);
-        return Convert.ToBase64String(bytes).Replace("+", "-").Replace("/", "_").TrimEnd('=');
+        // Cryptographically random, opaque token. It is validated by DB lookup
+        // (StoreOneTimeTokenAsync), so it must NOT encode adminId/tenantId/timestamp:
+        // doing so leaked identifiers and made the value structurally predictable.
+        var randomBytes = System.Security.Cryptography.RandomNumberGenerator.GetBytes(32);
+        return Convert.ToBase64String(randomBytes).Replace("+", "-").Replace("/", "_").TrimEnd('=');
     }
 
     private async Task StoreOneTimeTokenAsync(string token, int adminId, string tenantId, TimeSpan expiry)


### PR DESCRIPTION
## Summary
Closes #9 — three HIGH hardening fixes on the management/provisioning API.

### 1. Require HTTPS metadata in production
`Program.cs:67` — `RequireHttpsMetadata = false` (unconditional) → `!builder.Environment.IsDevelopment()`. JWT bearer now requires HTTPS outside Development.

### 2. Remove `"dev-secret"` signing fallback
`SuperAdminService.GenerateRequestSignature` defaulted the HMAC key to `"dev-secret"` when `SUPER_ADMIN_SHARED_SECRET` was unset. Tenant APIs trust this signature to grant a super-admin session into any tenant, so a known default key = forge `X-SuperAdmin-Signature` → log into any tenant. Now fails fast if the secret is missing.

### 3. Cryptographically random one-time access token
`GenerateOneTimeAccessToken` returned `base64(adminId:tenantId:ticks:guid)` — leaked identifiers and was structurally predictable. Now 32 bytes from `RandomNumberGenerator`. The token is validated by DB lookup (`StoreOneTimeTokenAsync`), so it needn't encode any data.

## Verification
- `dotnet build -c Release` succeeds (0 errors).

## Ops note
Deploys must now set `SUPER_ADMIN_SHARED_SECRET` (covered by the secret-management work in #5/#28) or cross-tenant access requests will throw by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)