### PR TITLE
fix(security): gate CI deploy to push/main + block fork PRs (#8)

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -6,9 +6,6 @@ on:
       db-host:
         required: true
         type: string
-      db-password:
-        required: true
-        type: string
       application-host:
         required: true
         type: string
@@ -18,30 +15,35 @@ on:
       application-path:
         required: true
         type: string
-      ssh-key:
-        required: true
-        type: string
-      consumer-secret:
-        required: true
-        type: string
-      jwt-secret:
-        required: true
-        type: string
       smtp-host:
         required: true
         type: string
       smtp-port:
         required: true
         type: string
-      smtp-user:
-        required: true
-        type: string
-      smtp-password:
-        required: true
-        type: string
       cors-apphost:
         required: true
         type: string
+      # When false (the default) the workflow builds and validates only.
+      # Deploy steps (rsync + remote migrations/restart) run ONLY when the
+      # caller explicitly opts in — i.e. on push to main, never on pull_request.
+      deploy:
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      db-password:
+        required: true
+      ssh-key:
+        required: true
+      consumer-secret:
+        required: true
+      jwt-secret:
+        required: true
+      smtp-user:
+        required: true
+      smtp-password:
+        required: true
 
 jobs:
   build:
@@ -76,16 +78,16 @@ jobs:
         with:
           files: "backend/src/MechanicBuddy.Http.Api/appsettings.Secrets.json"
         env:
-          JwtOptions.Secret: "${{ inputs.jwt-secret }}"
-          JwtOptions.ConsumerSecret: "${{ inputs.consumer-secret }}"
+          JwtOptions.Secret: "${{ secrets.jwt-secret }}"
+          JwtOptions.ConsumerSecret: "${{ secrets.consumer-secret }}"
           DbOptions.Host: "${{ inputs.db-host }}"
           DbOptions.UserId: "postgres"
-          DbOptions.Password: "${{ inputs.db-password }}"
+          DbOptions.Password: "${{ secrets.db-password }}"
           DbOptions.MultiTenancy.Enabled: true
           SmtpOptions.Host: "${{ inputs.smtp-host }}"
           SmtpOptions.Port: "${{ inputs.smtp-port }}"
-          SmtpOptions.User: "${{ inputs.smtp-user }}"
-          SmtpOptions.Password: "${{ inputs.smtp-password }}"
+          SmtpOptions.User: "${{ secrets.smtp-user }}"
+          SmtpOptions.Password: "${{ secrets.smtp-password }}"
           GoogleRecaptchaV3:Secret: "secretapikey"
           Cors.AppHost: "${{ inputs.cors-apphost }}"
 
@@ -105,8 +107,9 @@ jobs:
         working-directory: backend/src/DbUp
 
       # ---------------------------------------------------------------------
-      #  Deploy ------------------------------------------------------------------
+      #  Deploy (push to main only — gated by the `deploy` input) ----------------
       - name: Deploy DbUp with rsync
+        if: ${{ inputs.deploy }}
         uses: burnett01/rsync-deployments@7.0.2
         with:
           switches: -avzr --delete
@@ -114,9 +117,10 @@ jobs:
           remote_path: ${{ inputs.application-path }}
           remote_host: ${{ inputs.application-host }}
           remote_user: ${{ inputs.application-host-user }}
-          remote_key: ${{ inputs.ssh-key }}
+          remote_key: ${{ secrets.ssh-key }}
 
       - name: Deploy API with rsync
+        if: ${{ inputs.deploy }}
         uses: burnett01/rsync-deployments@7.0.2
         with:
           switches: -avzr --delete --exclude="MechanicBuddy.Http.Api.staticwebassets.runtime.json"
@@ -124,14 +128,15 @@ jobs:
           remote_path: ${{ inputs.application-path }}
           remote_host: ${{ inputs.application-host }}
           remote_user: ${{ inputs.application-host-user }}
-          remote_key: ${{ inputs.ssh-key }}
+          remote_key: ${{ secrets.ssh-key }}
 
       - name: Run DbUp migrations and reload API
+        if: ${{ inputs.deploy }}
         uses: appleboy/ssh-action@v1.2.1
         with:
           host: ${{ inputs.application-host }}
           username: ${{ inputs.application-host-user }}
-          key: ${{ inputs.ssh-key }}
+          key: ${{ secrets.ssh-key }}
           script: |
             sudo service mechanicbuddy stop
             ${{ inputs.application-path }}dbup/DbUp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,32 +10,45 @@ on:
 
 jobs:
   backend:
-    if: contains(github.event.head_commit.message, '[skip-backend]') == false
+    # Skip on request, and never run for pull requests opened from forks
+    # (a fork PR must not be able to reach deploy secrets or production).
+    if: >-
+      contains(github.event.head_commit.message, '[skip-backend]') == false &&
+      (github.event_name == 'push' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/backend-build.yml
     with:
       db-host: localhost
-      db-password: ${{ secrets.DB_PASSWORD }}
       application-host: ${{ vars.APPLICATION_HOST }}
       application-path: /opt/apps/
-      ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      jwt-secret: ${{ secrets.JWT_SECRET }}
-      consumer-secret: ${{ secrets.CONSUMER_SECRET }}
       application-host-user: debian
       smtp-host: ${{ secrets.SMTP_HOST }}
       smtp-port: 587
-      smtp-password: ${{ secrets.SMTP_PASSWORD }}
-      smtp-user: ${{ secrets.SMTP_USER }}
       cors-apphost: ${{ vars.APPLICATION_HOST }}
+      # Deploy ONLY on push to main — pull_request builds validate but never ship.
+      deploy: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    secrets:
+      db-password: ${{ secrets.DB_PASSWORD }}
+      ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      jwt-secret: ${{ secrets.JWT_SECRET }}
+      consumer-secret: ${{ secrets.CONSUMER_SECRET }}
+      smtp-user: ${{ secrets.SMTP_USER }}
+      smtp-password: ${{ secrets.SMTP_PASSWORD }}
 
   frontend:
-    if: contains(github.event.head_commit.message, '[skip-frontend]') == false
+    if: >-
+      contains(github.event.head_commit.message, '[skip-frontend]') == false &&
+      (github.event_name == 'push' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/frontend-build.yml
     with:
       api-url: http://localhost:15567
       public-api-url: ${{ vars.PUBLIC_API_URL }}
       application-host: ${{ vars.APPLICATION_HOST }}
       application-path: /opt/apps/
+      application-host-user: debian
+      deploy: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    secrets:
       ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
       consumer-secret: ${{ secrets.CONSUMER_SECRET }}
       session-secret: ${{ secrets.SESSION_SECRET }}
-      application-host-user: debian

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -18,15 +18,19 @@ on:
       public-api-url:
         required: true
         type: string
+      # When false (the default) the workflow builds and validates only.
+      # Deploy steps run ONLY when the caller opts in (push to main).
+      deploy:
+        required: false
+        type: boolean
+        default: false
+    secrets:
       ssh-key:
         required: true
-        type: string
       consumer-secret:
         required: true
-        type: string
       session-secret:
         required: true
-        type: string
 
 jobs:
   Run-Build:
@@ -59,14 +63,13 @@ jobs:
     - name: 'Create env file'
       run: |
        touch .env
-       echo SERVER_SECRET=${{ inputs.consumer-secret }} >> .env
-       echo "SESSION_SECRET=${{ inputs.session-secret }}" >> .env
+       echo SERVER_SECRET=${{ secrets.consumer-secret }} >> .env
+       echo "SESSION_SECRET=${{ secrets.session-secret }}" >> .env
        echo API_URL=${{ inputs.api-url }} >> .env
        echo NEXT_PUBLIC_API_URL=${{ inputs.public-api-url }} >> .env
        echo NEXT_PUBLIC_SESSION_TIMEOUT=604800 >> .env
        echo NEXT_PUBLIC_SESSION_DIALOG_TIMEOUT=120 >> .env
        echo NEXT_TELEMETRY_DISABLED=1 >> .env
-       cat .env
 
     - name: Running build
       run: npm run build
@@ -75,6 +78,7 @@ jobs:
       run: rm -rf src
 
     - name: Deploy with rsync
+      if: ${{ inputs.deploy }}
       uses: burnett01/rsync-deployments@7.0.2
       with:
         switches: -avzr --delete  --exclude=".git" --exclude=".github" --exclude=".vscode" --exclude="node_modules"
@@ -82,12 +86,13 @@ jobs:
         remote_path: ${{ inputs.application-path }}mechanicbuddy-app/
         remote_host: ${{ inputs.application-host }}
         remote_user: ${{ inputs.application-host-user }}
-        remote_key: ${{ inputs.ssh-key }}
+        remote_key: ${{ secrets.ssh-key }}
 
     - name: Reloading mechanicbuddy-app pm2 process
+      if: ${{ inputs.deploy }}
       uses: appleboy/ssh-action@v1.2.1
       with:
         host: ${{ inputs.application-host }}
         username: ${{ inputs.application-host-user }}
-        key: ${{ inputs.ssh-key }}
+        key: ${{ secrets.ssh-key }}
         script: "cd ${{ inputs.application-path }}mechanicbuddy-app; pwd; npm install; pm2 reload mechanicbuddy-app"


### PR DESCRIPTION
## Summary
Closes #8 — **HIGH**: CI deployed to production on every `pull_request`.

The reusable `backend-build.yml` / `frontend-build.yml` ran their rsync + remote SSH steps (`service mechanicbuddy stop` → run DbUp migrations → restart) unconditionally. Any PR that built shipped its code to prod and ran arbitrary migrations against the prod DB.

## Changes
- **Deploy gate**: new `deploy` boolean input (default `false`); every rsync/SSH step is now `if: ${{ inputs.deploy }}`. `ci.yml` sets `deploy` only for `github.event_name == 'push' && github.ref == 'refs/heads/main'`.
- **Fork protection**: both jobs require `github.event.pull_request.head.repo.full_name == github.repository` (or a push), so fork PRs can't reach deploy secrets/prod.
- **Secrets hygiene**: moved `db-password`, `ssh-key`, `jwt-secret`, `consumer-secret`, `session-secret`, `smtp-user`, `smtp-password` from `inputs:` (type string) into the reusable workflows' `secrets:` block.
- **Log leak**: removed `cat .env` from the frontend build (it printed `SERVER_SECRET`/`SESSION_SECRET` into logs).

## Verification
- All three workflows validated with `yaml.safe_load` (parse cleanly).
- Behavior: `pull_request` → build only; `push` to `main` → build + deploy.

## Follow-up
For belt-and-suspenders, consider also putting the deploy behind a GitHub **Environment** with required reviewers (noted in #8). Not included here to keep the diff reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)