### PR TITLE
fix(security): SQL injection via orderby in UserManagementController (#14)

### DIFF
--- a/backend/src/MechanicBuddy.Http.Api/Controllers/UserManagementController.cs
+++ b/backend/src/MechanicBuddy.Http.Api/Controllers/UserManagementController.cs
@@ -31,6 +31,14 @@ namespace MechanicBuddy.Http.Api.Controllers
         private readonly ISession session;
         private readonly DbOptions dbOptions;
 
+        // Security: allow-list of sortable employee columns. `orderby` is
+        // interpolated into the ORDER BY clause, so only these values may be used.
+        private static readonly HashSet<string> AllowedOrderByColumns =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                "introducedat", "firstname", "lastname", "email", "phone", "proffession"
+            };
+
         public UserManagementController(
             IUserRepository userRepository,
             IRepository repository,
@@ -115,8 +123,13 @@ namespace MechanicBuddy.Http.Api.Controllers
 
             using (var connection = CreateConnection())
             {
-                // Build the query
-                var orderByClause = string.IsNullOrEmpty(orderby) ? "e.introducedat" : $"e.{orderby}";
+                // Build the query.
+                // Security: `orderby` is interpolated into SQL, so restrict it to
+                // an allow-listed column; anything else falls back to the default.
+                var orderColumn = AllowedOrderByColumns.Contains(orderby ?? string.Empty)
+                    ? orderby
+                    : "introducedat";
+                var orderByClause = $"e.{orderColumn}";
                 var orderDirection = desc ? "DESC" : "ASC";
 
                 var whereClause = string.IsNullOrEmpty(searchText)


### PR DESCRIPTION
## Summary
Closes #14 — **HIGH**: SQL injection in `UserManagementController.GetPage`.

`orderByClause` was `$"e.{orderby}"` built from the raw query param and interpolated into `ORDER BY {orderByClause} {orderDirection}`, so an authenticated tenant user could inject into the ORDER BY clause.

## Change
- Added `AllowedOrderByColumns` (case-insensitive allow-list of sortable `employee` columns: `introducedat, firstname, lastname, email, phone, proffession`).
- `orderby` is matched against the allow-list; non-matching input falls back to the default `introducedat` ordering. The interpolated value can now only be a known-safe column name.

Audited the other controllers — the remaining `orderby` paths go through `PageResultQuery`, which already validates against `ValidOrderByPattern`. This controller was the only one bypassing it.

## Verification
- `dotnet build -c Release` (Http.Api) succeeds (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)