### PR TITLE
fix(security): validate + escape tenantId in DB provisioner (#10)

### DIFF
--- a/backend/src/MechanicBuddy.Management.Api/Infrastructure/TenantDatabaseProvisioner.cs
+++ b/backend/src/MechanicBuddy.Management.Api/Infrastructure/TenantDatabaseProvisioner.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Npgsql;
 
 namespace MechanicBuddy.Management.Api.Infrastructure;
@@ -86,7 +87,7 @@ public class TenantDatabaseProvisioner : ITenantDatabaseProvisioner
                 {
                     // Create database from template
                     // Note: Need to use dynamic SQL since parameterized identifiers aren't supported
-                    var createDbSql = $"CREATE DATABASE \"{tenantDbName}\" WITH TEMPLATE \"{_templateDbName}\" OWNER \"{_postgresUser}\"";
+                    var createDbSql = $"CREATE DATABASE \"{QuoteIdentifier(tenantDbName)}\" WITH TEMPLATE \"{QuoteIdentifier(_templateDbName)}\" OWNER \"{QuoteIdentifier(_postgresUser)}\"";
                     await using var createCmd = new NpgsqlCommand(createDbSql, adminConnection);
                     await createCmd.ExecuteNonQueryAsync();
 
@@ -157,7 +158,7 @@ public class TenantDatabaseProvisioner : ITenantDatabaseProvisioner
 
             // Drop the database
             await using (var dropCmd = new NpgsqlCommand(
-                $"DROP DATABASE IF EXISTS \"{tenantDbName}\"", adminConnection))
+                $"DROP DATABASE IF EXISTS \"{QuoteIdentifier(tenantDbName)}\"", adminConnection))
             {
                 await dropCmd.ExecuteNonQueryAsync();
             }
@@ -221,9 +222,31 @@ public class TenantDatabaseProvisioner : ITenantDatabaseProvisioner
         return rowsAffected;
     }
 
+    // Security: tenant IDs reach raw SQL (CREATE/DROP DATABASE) and Postgres
+    // identifiers cannot be parameterized, so every tenant ID must match this
+    // strict pattern before it is used to build a database name.
+    private static readonly Regex TenantIdPattern =
+        new("^[a-z0-9][a-z0-9-]{1,29}$", RegexOptions.Compiled);
+
+    private static void ValidateTenantId(string tenantId)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId) || !TenantIdPattern.IsMatch(tenantId))
+        {
+            throw new ArgumentException(
+                $"Invalid tenant identifier '{tenantId}'. Tenant IDs must be 2-30 chars, " +
+                "lowercase letters/digits/hyphens, starting with a letter or digit.");
+        }
+    }
+
+    // Escapes a value for safe use as a quoted Postgres identifier (defense in
+    // depth on top of ValidateTenantId / trusted config).
+    private static string QuoteIdentifier(string identifier) =>
+        identifier.Replace("\"", "\"\"");
+
     private string GetTenantDbName(string tenantId)
     {
         // Database naming: mechanicbuddy-{tenantId}
+        ValidateTenantId(tenantId);
         return $"{_tenantDbPrefix}-{tenantId}";
     }
 


### PR DESCRIPTION
## Summary
Closes #10 — **CRITICAL**: SQL injection in tenant database provisioning.

`CREATE DATABASE "{tenantDbName}" WITH TEMPLATE ... OWNER ...` and `DROP DATABASE IF EXISTS "{tenantDbName}"` interpolated `tenantId`-derived identifiers into SQL executed as the Postgres superuser, with no escaping. Postgres identifiers can't be parameterized, so an attacker-influenced `tenantId` could break out and run arbitrary SQL against the shared cluster.

## Changes
- `ValidateTenantId`: strict `^[a-z0-9][a-z0-9-]{1,29}$`, enforced inside `GetTenantDbName` — the single choke point every provisioning SQL path (create/drop/exists/update/disable) flows through. Invalid IDs throw `ArgumentException` before any SQL runs.
- `QuoteIdentifier` (`"` → `""`) applied to the `CREATE`/`DROP` identifiers (tenant DB name, template, owner) as defense in depth.

## Verification
- `dotnet build -c Release` (Management.Api) succeeds (0 errors).
- Pattern accepts existing lowercase DNS-label tenant IDs (also used for `{tenantId}.mechanicbuddy.app` subdomains and `tenant-{tenantId}` namespaces); rejects anything with quotes/semicolons/whitespace.

## Related
Helm/namespace interpolation of the same `tenantId` is handled in #11; route-level `{tenantId}` validation on deprovision/delete/migrate in #33-adjacent work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)