### PR TITLE
fix(security): stop trusting client headers for login tenant (#12)

### DIFF
--- a/backend/src/MechanicBuddy.Core.Application/Configuration/Options.cs
+++ b/backend/src/MechanicBuddy.Core.Application/Configuration/Options.cs
@@ -36,6 +36,14 @@ namespace MechanicBuddy.Core.Application.Configuration
             public string TenantId { get; set; }
             public SuffixOptions Suffix { get; set; }
 
+            // Security: when true, the tenant may be resolved from the
+            // X-Tenant-ID / X-Forwarded-Host request headers. Enable this ONLY
+            // when a trusted ingress/edge injects these headers AND strips any
+            // client-supplied copy. When false (the default) those headers are
+            // ignored and the tenant is taken from the connection Host only,
+            // so a direct caller cannot select another tenant at login.
+            public bool TrustProxyHeaders { get; set; }
+
 
             public class SuffixOptions
             {

--- a/backend/src/MechanicBuddy.Core.Persistence.Postgres/UserRepository.cs
+++ b/backend/src/MechanicBuddy.Core.Persistence.Postgres/UserRepository.cs
@@ -60,44 +60,58 @@ namespace MechanicBuddy.Core.Repository.Postgres
                 return dbOptions.MultiTenancy.TenantId;
             }
 
-            // For shared instances, resolve from HTTP headers
+            // For shared instances, resolve from the request.
             var httpContext = _httpContextAccessor?.HttpContext;
-            if (httpContext == null)
+            if (httpContext?.Request == null)
             {
                 return null;
             }
 
-            // Priority: X-Tenant-ID > X-Forwarded-Host > Host
-            if (httpContext.Request?.Headers?.TryGetValue("X-Tenant-ID", out var tenantIdHeader) == true)
+            // SECURITY: X-Tenant-ID and X-Forwarded-Host are client-controllable.
+            // Honoring them at login lets a direct caller authenticate against an
+            // arbitrary tenant's users (the shared public.user table is keyed by
+            // tenant name). Only trust them when an authenticated ingress is known
+            // to inject these headers and strip any client-supplied copy.
+            if (dbOptions.MultiTenancy?.TrustProxyHeaders == true)
             {
-                var headerValue = tenantIdHeader.ToString();
-                if (!string.IsNullOrEmpty(headerValue))
+                if (httpContext.Request.Headers.TryGetValue("X-Tenant-ID", out var tenantIdHeader))
                 {
-                    return headerValue;
-                }
-            }
-
-            if (httpContext.Request?.Headers?.TryGetValue("X-Forwarded-Host", out var forwardedHost) == true)
-            {
-                var host = forwardedHost.ToString();
-                if (!string.IsNullOrEmpty(host))
-                {
-                    var parts = host.Split('.');
-                    if (parts.Length >= 2 && !string.IsNullOrEmpty(parts[0]) && parts[0] != "www" && parts[0] != "api")
+                    var headerValue = tenantIdHeader.ToString();
+                    if (!string.IsNullOrEmpty(headerValue))
                     {
-                        return parts[0];
+                        return headerValue;
+                    }
+                }
+
+                if (httpContext.Request.Headers.TryGetValue("X-Forwarded-Host", out var forwardedHost))
+                {
+                    var fromForwarded = TenantFromHost(forwardedHost.ToString());
+                    if (fromForwarded != null)
+                    {
+                        return fromForwarded;
                     }
                 }
             }
 
-            if (httpContext.Request?.Host.Host != null)
+            // Default: derive the tenant from the connection Host only.
+            return TenantFromHost(httpContext.Request.Host.Host);
+        }
+
+        /// <summary>
+        /// Extracts the tenant subdomain label from a host, or null when it is
+        /// not a tenant host (bare domain, www, api).
+        /// </summary>
+        private static string TenantFromHost(string host)
+        {
+            if (string.IsNullOrEmpty(host))
             {
-                var host = httpContext.Request.Host.Host;
-                var parts = host.Split('.');
-                if (parts.Length >= 2 && !string.IsNullOrEmpty(parts[0]) && parts[0] != "www" && parts[0] != "api")
-                {
-                    return parts[0];
-                }
+                return null;
+            }
+
+            var parts = host.Split('.');
+            if (parts.Length >= 2 && !string.IsNullOrEmpty(parts[0]) && parts[0] != "www" && parts[0] != "api")
+            {
+                return parts[0];
             }
 
             return null;


### PR DESCRIPTION
## Summary
Closes #12 — **CRITICAL**: cross-tenant authentication via a forged header.

`UserRepository.ResolveTenantId()` (shared instances) resolved the login tenant from `X-Tenant-ID` > `X-Forwarded-Host` > `Host`. The first two are fully client-controlled, and the shared `public.user` table is keyed by tenant name — so a direct caller could send `X-Tenant-ID: victim-tenant` + `admin`/`carcare` and authenticate as another tenant's admin.

## Change
- New `MultiTenancy.TrustProxyHeaders` option (**default `false`**). `X-Tenant-ID` / `X-Forwarded-Host` are honored **only** when it's enabled — i.e. when a trusted ingress injects those headers and strips any client-supplied copy.
- By default the tenant is derived from the **connection `Host`** subdomain only; a direct caller can no longer pick another tenant at login.
- Extracted `TenantFromHost` helper (shared by the Host and forwarded-host paths).
- **Dedicated** instances are unaffected — they use the configured `MultiTenancy.TenantId`.

## Migration note
Shared deployments that currently rely on the frontend setting `X-Tenant-ID` must either (a) route by subdomain so `Host` carries the tenant (recommended), or (b) set `TrustProxyHeaders: true` **and** configure the ingress to strip client-supplied `X-Tenant-ID`/`X-Forwarded-Host`. This is the secure-by-default posture; the previous behavior trusted the header unconditionally.

## Defense in depth (follow-up)
Validating the resolved tenant against the tenant registry would further harden Host-spoofing on shared pods — noted for a follow-up.

## Verification
- `dotnet build -c Release` (Http.Api, pulls in both projects) succeeds (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)