### PR TITLE
fix(security): avatar via /api/profile-image, drop JWT-in-URL (#17)

### DIFF
--- a/frontend/src/app/home/layout.tsx
+++ b/frontend/src/app/home/layout.tsx
@@ -57,8 +57,10 @@ export default async function Layout({ children }: { children: React.ReactNode }
     // Fetch branding data
     const branding = await getBranding();
 
-    // Use proxy path for profile picture to avoid NEXT_PUBLIC_API_URL build-time issues
-    const imageUrl = `/backend-api/users/profilepicture/${jwt}`
+    // Security: use the server-side profile-image route, which reads the JWT
+    // from the httpOnly cookie. Never put the JWT in a URL (it leaks via access
+    // logs, browser history and the Referer header).
+    const imageUrl = `/api/profile-image`
 
     // Generate inline CSS for immediate color application (prevents flash)
     // Security: Validate and escape all color values to prevent CSS injection


### PR DESCRIPTION
## Summary
Closes #17 — **HIGH**: API JWT placed in a URL.

`home/layout.tsx` set the avatar `src` to `/backend-api/users/profilepicture/${jwt}`, exposing the full API token in a URL — it leaks via proxy/access logs, browser history, and the `Referer` header on outbound navigation/assets.

## Change
- Point `imageUrl` at the existing server-side `/api/profile-image` route, which reads the JWT from the httpOnly cookie (no token in the URL). `jwt` is still decoded server-side for the token payload, so no other behavior changes.

## Verification
- `npx tsc --noEmit` shows no new errors in `layout.tsx` (remaining errors are pre-existing asset-import module declarations unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)