### PR TITLE
fix(security): secure cookies in prod + stop logging secrets (#18)

### DIFF
--- a/frontend/src/_lib/server/query-api.ts
+++ b/frontend/src/_lib/server/query-api.ts
@@ -58,13 +58,11 @@ async function apiCall({
    
   const response = await fetch(fullUrl,request);
   if (!response.ok) {
-    debugger;
     const responseText = await response.text();
-    console.log("API response content type header: " + response.headers.get('Content-Type'));
-    console.log("API threw an exception: " + responseText);
-    console.log(method+' request to: '+fullUrl);
-    console.log('headers: '+JSON.stringify(requestHeaders));
-    console.log('body: '+request.body);
+    // Do NOT log request headers (contains Authorization) or the request body.
+    if (process.env.NODE_ENV !== 'production') {
+      console.error(`API error: ${method} ${fullUrl} -> ${response.status}`);
+    }
     const hasContentType = response.headers.has('Content-Type');
     let message = 'API Error occurred server side';
     let isUserError = false;

--- a/frontend/src/_lib/server/session.ts
+++ b/frontend/src/_lib/server/session.ts
@@ -41,9 +41,11 @@ export async function createSession(rootJwt: string,publicJwt: string,mustChange
   expiresAt.setSeconds(expiresAt.getSeconds() + parseInt(sessionTimeoutInSecondsString));
   const session = await encrypt({ apiRootJwt:rootJwt, expiresAt, mustChangePassword })
   const cookieStore = await cookies()
+  // Secure in production so cookies are only sent over HTTPS; allow HTTP in dev.
+  const secureCookie = process.env.NODE_ENV === 'production'
   cookieStore.set('session', session, {
     httpOnly: true, //jwt not accessible by browser
-    secure: false,
+    secure: secureCookie,
     expires: expiresAt,
     sameSite: 'lax',
     path: '/',
@@ -51,7 +53,7 @@ export async function createSession(rootJwt: string,publicJwt: string,mustChange
   //jwt for public side resources
   cookieStore.set('jwt',  publicJwt, {
     httpOnly: false,
-    secure: false,
+    secure: secureCookie,
     expires: expiresAt,
     sameSite: 'lax',
     path: '/',
@@ -59,7 +61,7 @@ export async function createSession(rootJwt: string,publicJwt: string,mustChange
    //browser app has to know when session started so it can call extend session before api jwt times out
   cookieStore.set('session_timestamp',  Date.now().toString(), {
     httpOnly: false,
-    secure: false,
+    secure: secureCookie,
     expires: expiresAt,
     sameSite: 'lax',
     path: '/',

--- a/frontend/src/app/api/servicerequest/[id]/status/route.ts
+++ b/frontend/src/app/api/servicerequest/[id]/status/route.ts
@@ -7,21 +7,13 @@ const encodedKey = new TextEncoder().encode(secretKey)
 
 async function getJwtFromCookies() {
   const cookieStore = await cookies()
-  const allCookies = cookieStore.getAll()
-  console.log("All cookies:", allCookies.map(c => c.name))
-  
   const session = cookieStore.get("session")?.value
-  console.log("Session cookie present:", !!session)
-  console.log("Session cookie length:", session?.length || 0)
-  
   if (!session) return null
-  
+
   try {
     const { payload } = await jwtVerify(session, encodedKey, { algorithms: ["HS256"] })
-    console.log("JWT decoded successfully, has apiRootJwt:", !!payload.apiRootJwt)
     return payload.apiRootJwt as string
-  } catch (err) {
-    console.error("JWT decode error:", err)
+  } catch {
     return null
   }
 }
@@ -30,23 +22,17 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  console.log("PUT /api/servicerequest/[id]/status called")
-  console.log("Request headers:", Object.fromEntries(request.headers.entries()))
-  
   try {
     const jwt = await getJwtFromCookies()
     if (!jwt) {
-      console.error("No JWT available")
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
 
     const { id } = await params
     const body = await request.json()
-    console.log("Updating status for:", id, "to:", body.status)
-    
+
     const backendUrl = `${process.env.API_URL}/api/servicerequest/${id}/status`
-    console.log("Backend URL:", backendUrl)
-    
+
     const response = await fetch(backendUrl, {
       method: "PUT",
       headers: {
@@ -56,11 +42,7 @@ export async function PUT(
       body: JSON.stringify(body)
     })
 
-    console.log("Backend response status:", response.status)
-
     if (!response.ok) {
-      const text = await response.text()
-      console.error("Backend error:", response.status, text)
       return NextResponse.json({ error: "Backend error" }, { status: response.status })
     }
 


### PR DESCRIPTION
## Summary
Closes #18 — **MEDIUM**: cookies sent over HTTP + secrets written to logs.

## Changes
- **`session.ts`**: `session`, `jwt`, `session_timestamp` were hardcoded `secure: false`. Now `secure: process.env.NODE_ENV === 'production'`, so they only travel over HTTPS in prod (HTTP still allowed in dev).
- **`query-api.ts`**: removed the `debugger;` statement and the `console.log` of `requestHeaders` (contains `Authorization: Bearer …`) and request body. Kept a dev-only one-line error.
- **`servicerequest/[id]/status/route.ts`**: removed logging of all cookie names, session presence/length, and `Object.fromEntries(request.headers.entries())` (which includes the `Cookie` header), plus assorted debug logs.

## Verification
- `npx tsc --noEmit` — no errors in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)