### PR TITLE
fix(security): disallow SVG uploads + fail-closed magic bytes (#19)

### DIFF
--- a/backend/src/MechanicBuddy.Core.Application/Validation/ImageValidator.cs
+++ b/backend/src/MechanicBuddy.Core.Application/Validation/ImageValidator.cs
@@ -25,8 +25,10 @@ namespace MechanicBuddy.Core.Application.Validation
             "image/jpg",
             "image/png",
             "image/gif",
-            "image/webp",
-            "image/svg+xml"
+            "image/webp"
+            // SVG intentionally NOT allowed: SVG is XML and can carry <script>,
+            // and these images are served same-origin from anonymous endpoints,
+            // which would allow stored XSS.
         };
 
         // Magic bytes for common image formats
@@ -84,8 +86,7 @@ namespace MechanicBuddy.Core.Application.Validation
             }
 
             // Validate magic bytes (actual file content matches declared MIME type)
-            // Skip SVG as it's text-based
-            if (mimeType != "image/svg+xml" && !ValidateMagicBytes(imageBytes, mimeType))
+            if (!ValidateMagicBytes(imageBytes, mimeType))
             {
                 return ImageValidationResult.Failure("Image content does not match declared MIME type");
             }
@@ -198,8 +199,8 @@ namespace MechanicBuddy.Core.Application.Validation
 
             if (!MagicBytes.TryGetValue(lookupMime, out var expectedMagicBytesArray))
             {
-                // Unknown type, allow it (conservative approach for extensibility)
-                return true;
+                // Fail closed: a MIME type we cannot verify by magic bytes is rejected.
+                return false;
             }
 
             foreach (var expectedMagicBytes in expectedMagicBytesArray)


### PR DESCRIPTION
## Summary
Closes #19 — **MEDIUM**: stored XSS via SVG upload + fail-open content check.

`ImageValidator` allowed `image/svg+xml` and explicitly skipped magic-byte validation for it. Branding/profile images are served same-origin from anonymous endpoints, so a malicious SVG containing `<script>` ran as stored XSS. Separately, `ValidateMagicBytes` returned `true` for any MIME type not in its table (fail-open).

## Changes
- Removed `image/svg+xml` from `AllowedMimeTypes` (SVG uploads now rejected).
- Magic-byte validation now runs for every allowed type (removed the SVG special-case skip).
- Unknown MIME types now **fail closed** (`return false`).

## Verification
- `dotnet build -c Release` (Core.Application) succeeds (0 errors).

## Note
Existing SVG logos would fail re-validation on next upload; raster formats (jpeg/png/gif/webp) are unaffected. If SVG logos are a hard requirement, a follow-up could add server-side SVG sanitization instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)