### PR TITLE
fix(security): proxy injects auth from httpOnly session, JWT no longer JS-readable (#15)

### DIFF
--- a/frontend/src/_lib/client/query-api.ts
+++ b/frontend/src/_lib/client/query-api.ts
@@ -1,15 +1,7 @@
-import {
-    getCookie
-  } from 'cookies-next/client';
-
-// Use relative path for client-side API calls - Next.js rewrites will proxy to backend
+// Use relative path for client-side API calls - Next.js rewrites will proxy to backend.
+// The /backend-api proxy injects the Authorization header from the httpOnly session,
+// so the client neither reads nor sends the API token.
 const basePath = '/backend-api';
-
-const getJwtToken =()=>{
-
-    const jwt = getCookie('jwt');
-    return jwt;
-}
 
 // Extract tenant ID from hostname (e.g., "demo-1b94f2" from "demo-1b94f2.mechanicbuddy.app")
 const getTenantIdFromHost = (): string | null => {
@@ -95,13 +87,11 @@ const dataPage =({
 
     }) => {
 
-    const jwt = getJwtToken();
+    // No Authorization header here: the /backend-api proxy injects it from the
+    // httpOnly session. The client must not handle the API token.
     const headers:HeadersInit = {
       'Content-Type': 'application/json',
     };
-    if (jwt) {
-      headers['Authorization'] = 'Bearer ' + jwt;
-    }
 
     // Pass tenant ID to API for multi-tenant routing
     const tenantId = getTenantIdFromHost();

--- a/frontend/src/_lib/server/session.ts
+++ b/frontend/src/_lib/server/session.ts
@@ -48,9 +48,11 @@ export async function createSession(rootJwt: string,publicJwt: string,mustChange
     sameSite: 'lax',
     path: '/',
   })
-  //jwt for public side resources
+  // Public-side JWT. httpOnly so it is NOT readable by client-side JS; the only
+  // consumers are server components/routes (layout, profile-image, proxy), which
+  // read cookies server-side.
   cookieStore.set('jwt',  publicJwt, {
-    httpOnly: false,
+    httpOnly: true,
     secure: false,
     expires: expiresAt,
     sameSite: 'lax',

--- a/frontend/src/app/backend-api/[...path]/route.ts
+++ b/frontend/src/app/backend-api/[...path]/route.ts
@@ -1,6 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { jwtVerify } from 'jose';
 
 const API_URL = process.env.API_URL || 'http://localhost:15567';
+const encodedKey = new TextEncoder().encode(process.env.SESSION_SECRET);
+
+// Security: derive the API token from the httpOnly `session` cookie server-side.
+// The proxy must never trust a client-supplied Authorization header, and the
+// API token must never be exposed to client-side JavaScript.
+async function getApiTokenFromSession(): Promise<string | null> {
+  const session = (await cookies()).get('session')?.value;
+  if (!session) return null;
+  try {
+    const { payload } = await jwtVerify(session, encodedKey, { algorithms: ['HS256'] });
+    return (payload.apiRootJwt as string) ?? null;
+  } catch {
+    return null;
+  }
+}
 
 export async function GET(
   request: NextRequest,
@@ -47,11 +64,12 @@ async function proxyRequest(
 
   const headers = new Headers();
 
-  // Forward relevant headers
-  const authHeader = request.headers.get('authorization');
-  if (authHeader) {
-    headers.set('Authorization', authHeader);
+  // Authenticate from the httpOnly session — never from a client-supplied header.
+  const token = await getApiTokenFromSession();
+  if (!token) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+  headers.set('Authorization', `Bearer ${token}`);
 
   const contentType = request.headers.get('content-type');
   if (contentType) {


### PR DESCRIPTION
## Summary
Closes #15 — **CRITICAL**: API JWT exposed to client-side JS + open authenticated proxy.

The `/backend-api/[...path]` proxy forwarded a **client-supplied** `Authorization` header, and the client read the token from a **non-httpOnly `jwt` cookie**. Any XSS could read that cookie and exfiltrate a live API token, and the proxy blindly relayed whatever Authorization the client sent.

## Changes
- **Proxy** (`backend-api/[...path]/route.ts`): reads and verifies the httpOnly `session` cookie server-side (`jwtVerify` with `SESSION_SECRET`), extracts `apiRootJwt`, and injects `Authorization: Bearer …` itself. Returns **401** when there's no valid session. No longer trusts any client Authorization header.
- **Client** (`_lib/client/query-api.ts`): no longer reads the `jwt` cookie or sets `Authorization` — removed the `cookies-next/client` read. The proxy authenticates the call.
- **Session** (`_lib/server/session.ts`): the `jwt` cookie is now **`httpOnly: true`**, so client JS can't read it. Remaining consumers (`home/layout.tsx`, `api/profile-image`, the proxy) all read it server-side.

## Verification
- `npx tsc --noEmit` — no errors in the changed files; confirmed no client-side `getCookie('jwt')` readers remain.
- ⚠️ Not runtime-tested (no backend running locally). Reviewer should smoke-test a client-side API call and avatar load after deploy. The proxy injects `apiRootJwt` (the same token server routes like `servicerequest/[id]/status` already use as bearer).

## Related
CSRF protection for the proxy/mutation routes is #20 (depends on this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)