### PR TITLE
fix(security): sign the management-portal session cookie (#21)

### DIFF
--- a/management-portal/middleware.ts
+++ b/management-portal/middleware.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { verifySession } from "@/_lib/session-crypto";
 
 const SESSION_COOKIE_NAME = "admin_session";
 
 // Routes that don't require authentication
 const publicRoutes = ["/login", "/register", "/forgot-password", "/demo", "/pricing", "/"];
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Allow public routes
@@ -33,25 +34,17 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
-  try {
-    const session = JSON.parse(sessionCookie.value);
-
-    // Check if session has expired locally
-    if (new Date(session.expiresAt) < new Date()) {
-      // Session expired - clear cookie and redirect
-      const response = NextResponse.redirect(new URL("/login", request.url));
-      response.cookies.delete(SESSION_COOKIE_NAME);
-      return response;
-    }
-
-    // Session exists and not expired - allow request
-    return NextResponse.next();
-  } catch {
-    // Invalid session cookie - clear it and redirect
+  // Verify the signature before trusting the session contents.
+  const session = await verifySession(sessionCookie.value);
+  if (!session || new Date(session.expiresAt) < new Date()) {
+    // Missing/forged/expired session - clear cookie and redirect
     const response = NextResponse.redirect(new URL("/login", request.url));
     response.cookies.delete(SESSION_COOKIE_NAME);
     return response;
   }
+
+  // Valid, unexpired session - allow request
+  return NextResponse.next();
 }
 
 export const config = {

--- a/management-portal/src/_lib/auth.ts
+++ b/management-portal/src/_lib/auth.ts
@@ -2,6 +2,7 @@
 
 import { cookies } from "next/headers";
 import type { AdminUser, LoginCredentials, AuthSession } from "@/types";
+import { signSession, verifySession } from "@/_lib/session-crypto";
 
 const API_URL = process.env.MANAGEMENT_API_URL || "http://localhost:15568";
 const SESSION_COOKIE_NAME = "admin_session";
@@ -42,9 +43,9 @@ export async function login(credentials: LoginCredentials): Promise<{ success: b
       expiresAt: new Date(Date.now() + SESSION_DURATION).toISOString(),
     };
 
-    // Set session cookie
+    // Set signed session cookie (tamper-evident)
     const cookieStore = await cookies();
-    cookieStore.set(SESSION_COOKIE_NAME, JSON.stringify(session), {
+    cookieStore.set(SESSION_COOKIE_NAME, await signSession(session), {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
       sameSite: "lax",
@@ -79,7 +80,12 @@ export async function getSession(): Promise<AuthSession | null> {
       return null;
     }
 
-    const session: AuthSession = JSON.parse(sessionCookie.value);
+    // Verify the signature before trusting any field (role/expiry/token).
+    const session = await verifySession(sessionCookie.value);
+    if (!session) {
+      await logout();
+      return null;
+    }
 
     // Check if session is expired
     if (new Date(session.expiresAt) < new Date()) {

--- a/management-portal/src/_lib/session-crypto.ts
+++ b/management-portal/src/_lib/session-crypto.ts
@@ -1,0 +1,75 @@
+import type { AuthSession } from "@/types";
+
+// HMAC-signed session cookie. Uses the Web Crypto API so it works in both the
+// Edge middleware and Node server actions, with no extra dependency.
+//
+// Format: base64url(payloadJson) + "." + base64url(hmacSha256(payloadJson))
+// The signature is verified before the payload is trusted, so a client cannot
+// forge role/expiry by editing the cookie.
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64UrlToBytes(value: string): Uint8Array {
+  let normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  while (normalized.length % 4 !== 0) {
+    normalized += "=";
+  }
+  const binary = atob(normalized);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+async function getKey(): Promise<CryptoKey> {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) {
+    throw new Error("SESSION_SECRET is not configured");
+  }
+  return crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+/** Returns a signed, tamper-evident cookie value for the given session. */
+export async function signSession(session: AuthSession): Promise<string> {
+  const payloadBytes = encoder.encode(JSON.stringify(session));
+  const key = await getKey();
+  const signature = new Uint8Array(await crypto.subtle.sign("HMAC", key, payloadBytes));
+  return `${bytesToBase64Url(payloadBytes)}.${bytesToBase64Url(signature)}`;
+}
+
+/** Verifies the signed cookie and returns the session, or null if invalid. */
+export async function verifySession(value: string | undefined | null): Promise<AuthSession | null> {
+  if (!value) return null;
+  const dot = value.indexOf(".");
+  if (dot <= 0 || dot === value.length - 1) return null;
+
+  const payloadB64 = value.slice(0, dot);
+  const signatureB64 = value.slice(dot + 1);
+
+  try {
+    const payloadBytes = base64UrlToBytes(payloadB64);
+    const signatureBytes = base64UrlToBytes(signatureB64);
+    const key = await getKey();
+    const valid = await crypto.subtle.verify("HMAC", key, signatureBytes, payloadBytes);
+    if (!valid) return null;
+    return JSON.parse(decoder.decode(payloadBytes)) as AuthSession;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
Closes #21 — **HIGH**: management-portal session was unsigned plaintext JSON.

`admin_session` stored `JSON.stringify({ user:{role}, token, expiresAt })` with no signature, and `middleware.ts` only `JSON.parse`d it — trusting `role`/`expiresAt` with no integrity check. A forged/edited cookie could assert `role: "admin"` and a far-future expiry to pass the middleware gate (`SESSION_SECRET` was declared in `.env.example` but never used).

## Changes
- **`session-crypto.ts`** (new): `signSession`/`verifySession` using HMAC-SHA256 via the **Web Crypto API** — works in both the Edge middleware and Node server actions, no new dependency — keyed by `SESSION_SECRET`. Format: `base64url(payload).base64url(hmac)`.
- **`auth.ts`**: sign the cookie on login; `getSession` verifies the signature before trusting any field.
- **`middleware.ts`**: now `async`; verifies the signature instead of `JSON.parse`, rejecting missing/forged/expired sessions.

## Ops note
`SESSION_SECRET` must be set for the portal (it was previously unused). If unset, signing/verification fails closed (no valid session).

## Verification
- Type-correct by inspection (`AuthSession` shape matches; `@/*`→`src/*`). ⚠️ Portal `node_modules` not installed locally, so no `next build` run — reviewer should build/smoke-test login + a protected route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)