### PR TITLE
fix(security): same-origin CSRF protection on mutation routes (#20)

### DIFF
--- a/frontend/src/_lib/server/csrf.ts
+++ b/frontend/src/_lib/server/csrf.ts
@@ -1,0 +1,40 @@
+import type { NextRequest } from 'next/server';
+
+/**
+ * Same-origin check for CSRF protection on state-changing requests.
+ *
+ * These routes authenticate from the auto-sent httpOnly session cookie, so a
+ * cross-site form/fetch could otherwise drive a state-changing request. We
+ * require the Origin (or, as a fallback, Referer) to match the request host.
+ * A state-changing request with no Origin/Referer is rejected.
+ */
+export function isSameOrigin(request: NextRequest): boolean {
+  const host = request.headers.get('host');
+  if (!host) return false;
+
+  const origin = request.headers.get('origin');
+  if (origin) {
+    try {
+      return new URL(origin).host === host;
+    } catch {
+      return false;
+    }
+  }
+
+  const referer = request.headers.get('referer');
+  if (referer) {
+    try {
+      return new URL(referer).host === host;
+    } catch {
+      return false;
+    }
+  }
+
+  // No Origin/Referer on a state-changing request -> reject.
+  return false;
+}
+
+/** Methods that do not change state and so don't need a CSRF check. */
+export function isSafeMethod(method: string): boolean {
+  return method === 'GET' || method === 'HEAD' || method === 'OPTIONS';
+}

--- a/frontend/src/app/api/servicerequest/[id]/route.ts
+++ b/frontend/src/app/api/servicerequest/[id]/route.ts
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers"
 import { jwtVerify } from "jose"
 import { NextRequest, NextResponse } from "next/server"
+import { isSameOrigin } from "@/_lib/server/csrf"
 
 const secretKey = process.env.SESSION_SECRET
 const encodedKey = new TextEncoder().encode(secretKey)
@@ -21,6 +22,9 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  if (!isSameOrigin(request)) {
+    return NextResponse.json({ error: "Cross-origin request blocked" }, { status: 403 })
+  }
   try {
     const jwt = await getJwtFromCookies()
     if (!jwt) {

--- a/frontend/src/app/api/servicerequest/[id]/status/route.ts
+++ b/frontend/src/app/api/servicerequest/[id]/status/route.ts
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers"
 import { jwtVerify } from "jose"
 import { NextRequest, NextResponse } from "next/server"
+import { isSameOrigin } from "@/_lib/server/csrf"
 
 const secretKey = process.env.SESSION_SECRET
 const encodedKey = new TextEncoder().encode(secretKey)
@@ -30,9 +31,12 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  if (!isSameOrigin(request)) {
+    return NextResponse.json({ error: "Cross-origin request blocked" }, { status: 403 })
+  }
   console.log("PUT /api/servicerequest/[id]/status called")
   console.log("Request headers:", Object.fromEntries(request.headers.entries()))
-  
+
   try {
     const jwt = await getJwtFromCookies()
     if (!jwt) {

--- a/frontend/src/app/backend-api/[...path]/route.ts
+++ b/frontend/src/app/backend-api/[...path]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { jwtVerify } from 'jose';
+import { isSameOrigin, isSafeMethod } from '@/_lib/server/csrf';
 
 const API_URL = process.env.API_URL || 'http://localhost:15567';
 const encodedKey = new TextEncoder().encode(process.env.SESSION_SECRET);
@@ -61,6 +62,11 @@ async function proxyRequest(
   const path = params.path.join('/');
   const searchParams = request.nextUrl.searchParams.toString();
   const url = `${API_URL}/api/${path}${searchParams ? `?${searchParams}` : ''}`;
+
+  // CSRF: state-changing requests must come from the same origin.
+  if (!isSafeMethod(request.method) && !isSameOrigin(request)) {
+    return NextResponse.json({ error: 'Cross-origin request blocked' }, { status: 403 });
+  }
 
   const headers = new Headers();
 


### PR DESCRIPTION
## Summary
Closes #20 — **MEDIUM**: no CSRF protection on state-changing routes.

**Stacked on #45 (#15)** — base branch is `security/p3-proxy-server-auth`. After #15 the proxy and `/api/servicerequest/*` routes authenticate from the auto-sent httpOnly session cookie, so a cross-site form/fetch could drive a state-changing request (previously the client sent a Bearer header, which isn't auto-sent and incidentally blocked CSRF).

## Changes
- New `_lib/server/csrf.ts`: `isSameOrigin(request)` (Origin → Referer must match Host; absent ⇒ rejected) and `isSafeMethod`.
- `/backend-api/[...path]` proxy: reject non-safe methods that fail the same-origin check (403).
- `DELETE /api/servicerequest/[id]` and `PUT /api/servicerequest/[id]/status`: same-origin check.

## Verification
- `npx tsc --noEmit` — no errors in changed files.

## Merge note
Rebase onto `main` once #45 merges. (Also lightly overlaps #43's edits to the status route; trivial to reconcile.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)