### PR TITLE
fix(security): per-tenant random admin password, stop seeding carcare (#23)

### DIFF
--- a/backend/src/MechanicBuddy.Management.Api/Infrastructure/ITenantDatabaseProvisioner.cs
+++ b/backend/src/MechanicBuddy.Management.Api/Infrastructure/ITenantDatabaseProvisioner.cs
@@ -18,8 +18,9 @@ public interface ITenantDatabaseProvisioner
     /// <param name="targetPostgresPort">Target PostgreSQL port (null = use default)</param>
     /// <param name="ownerEmail">Owner's email address for the admin account (null = use default)</param>
     /// <param name="ownerName">Owner's name for the admin account (null = use default)</param>
+    /// <param name="adminPassword">Plaintext admin password to set (null = generate a random one)</param>
     /// <returns>The connection string for the tenant database</returns>
-    Task<string> ProvisionTenantDatabaseAsync(string tenantId, string? targetPostgresHost, int? targetPostgresPort, string? ownerEmail = null, string? ownerName = null);
+    Task<string> ProvisionTenantDatabaseAsync(string tenantId, string? targetPostgresHost, int? targetPostgresPort, string? ownerEmail = null, string? ownerName = null, string? adminPassword = null);
 
     /// <summary>
     /// Deletes a tenant's database schema and all associated data from the default PostgreSQL host.

--- a/backend/src/MechanicBuddy.Management.Api/Infrastructure/SecurePasswordGenerator.cs
+++ b/backend/src/MechanicBuddy.Management.Api/Infrastructure/SecurePasswordGenerator.cs
@@ -1,0 +1,41 @@
+using System.Security.Cryptography;
+
+namespace MechanicBuddy.Management.Api.Infrastructure;
+
+/// <summary>
+/// Generates cryptographically-random passwords for per-tenant admin accounts.
+/// </summary>
+public static class SecurePasswordGenerator
+{
+    // Excludes ambiguous characters (0/O, 1/l/I) for readability when delivered.
+    private const string Lower = "abcdefghijkmnpqrstuvwxyz";
+    private const string Upper = "ABCDEFGHJKLMNPQRSTUVWXYZ";
+    private const string Digits = "23456789";
+    private const string Symbols = "!@#$%^&*-_=+";
+    private const string All = Lower + Upper + Digits + Symbols;
+
+    public static string Generate(int length = 20)
+    {
+        if (length < 12) length = 12;
+
+        var chars = new char[length];
+        // Guarantee at least one of each class so it passes complexity rules.
+        chars[0] = Lower[RandomNumberGenerator.GetInt32(Lower.Length)];
+        chars[1] = Upper[RandomNumberGenerator.GetInt32(Upper.Length)];
+        chars[2] = Digits[RandomNumberGenerator.GetInt32(Digits.Length)];
+        chars[3] = Symbols[RandomNumberGenerator.GetInt32(Symbols.Length)];
+        for (var i = 4; i < length; i++)
+        {
+            chars[i] = All[RandomNumberGenerator.GetInt32(All.Length)];
+        }
+
+        // Fisher–Yates shuffle so the guaranteed chars aren't always first.
+        for (var i = length - 1; i > 0; i--)
+        {
+            var j = RandomNumberGenerator.GetInt32(i + 1);
+            (chars[i], chars[j]) = (chars[j], chars[i]);
+        }
+
+        return new string(chars);
+    }
+}

--- a/backend/src/MechanicBuddy.Management.Api/Infrastructure/TenantDatabaseProvisioner.cs
+++ b/backend/src/MechanicBuddy.Management.Api/Infrastructure/TenantDatabaseProvisioner.cs
@@ -17,11 +17,6 @@ public class TenantDatabaseProvisioner : ITenantDatabaseProvisioner
     // Template employee ID (from mechanicbuddy-testt template database)
     private const string TemplateEmployeeId = "a7227c1f-3bbc-4367-a9b8-baa83d0f19ca";
 
-    // Default admin password - same as the application default "carcare"
-    private const string DefaultAdminPassword = "carcare";
-    // BCrypt hash of "carcare" - precomputed for consistency
-    private const string DefaultAdminPasswordHash = "$2a$11$zsTS62pGn5Cfca4CgqRJxebx45je/3nJj.puxIArFwtAjHew67m6i";
-
     public TenantDatabaseProvisioner(
         IConfiguration configuration,
         ILogger<TenantDatabaseProvisioner> logger)
@@ -56,7 +51,7 @@ public class TenantDatabaseProvisioner : ITenantDatabaseProvisioner
     /// <param name="ownerEmail">Owner's email address for the admin account (null = use default).</param>
     /// <param name="ownerName">Owner's name for the admin account (null = use default).</param>
     /// <returns>Connection string to the tenant database.</returns>
-    public async Task<string> ProvisionTenantDatabaseAsync(string tenantId, string? targetPostgresHost, int? targetPostgresPort, string? ownerEmail = null, string? ownerName = null)
+    public async Task<string> ProvisionTenantDatabaseAsync(string tenantId, string? targetPostgresHost, int? targetPostgresPort, string? ownerEmail = null, string? ownerName = null, string? adminPassword = null)
     {
         var tenantDbName = GetTenantDbName(tenantId);
         var postgresHost = targetPostgresHost ?? _postgresHost;
@@ -100,7 +95,7 @@ public class TenantDatabaseProvisioner : ITenantDatabaseProvisioner
 
         // Create admin user in tenancy database (always uses default host - shared tenancy DB)
         // But employee name update needs to use the target host where the tenant DB resides
-        await CreateDefaultAdminAsync(tenantId, postgresHost, postgresPort, ownerEmail, ownerName);
+        await CreateDefaultAdminAsync(tenantId, postgresHost, postgresPort, ownerEmail, ownerName, adminPassword);
 
         _logger.LogInformation("Successfully provisioned database for tenant {TenantId} on host {Host}", tenantId, postgresHost);
 
@@ -246,8 +241,13 @@ public class TenantDatabaseProvisioner : ITenantDatabaseProvisioner
             rowsAffected, tenantDbName, tenantId);
     }
 
-    private async Task CreateDefaultAdminAsync(string tenantId, string postgresHost, int postgresPort, string? ownerEmail = null, string? ownerName = null)
+    private async Task CreateDefaultAdminAsync(string tenantId, string postgresHost, int postgresPort, string? ownerEmail = null, string? ownerName = null, string? adminPassword = null)
     {
+        // Use the supplied password or generate a cryptographically-random one.
+        var plaintextPassword = string.IsNullOrEmpty(adminPassword)
+            ? SecurePasswordGenerator.Generate()
+            : adminPassword;
+        var passwordHash = BCrypt.Net.BCrypt.HashPassword(plaintextPassword);
         // Create admin user in the tenancy database (where all users are stored)
         // The employee record already exists in the cloned tenant database from the template
         var tenancyConnectionString = BuildConnectionString(_tenancyDbName);
@@ -273,14 +273,14 @@ public class TenantDatabaseProvisioner : ITenantDatabaseProvisioner
             }
         }
 
-        // Create the admin user with the default "carcare" password
-        // Users will be prompted to change password on first login
+        // Create the admin user with a per-tenant random password.
+        // Users are prompted to change password on first login.
         await using (var cmd = new NpgsqlCommand(@"
             INSERT INTO public.""user"" (username, password, tenantname, email, validated, profile_image, employeeid, must_change_password)
             VALUES (@username, @password, @tenantname, @email, @validated, @profileImage, @employeeId, @mustChangePassword)", connection))
         {
             cmd.Parameters.AddWithValue("username", "admin");
-            cmd.Parameters.AddWithValue("password", DefaultAdminPasswordHash);
+            cmd.Parameters.AddWithValue("password", passwordHash);
             cmd.Parameters.AddWithValue("tenantname", tenantId);
             cmd.Parameters.AddWithValue("email", email);
             cmd.Parameters.AddWithValue("validated", true);
@@ -297,8 +297,8 @@ public class TenantDatabaseProvisioner : ITenantDatabaseProvisioner
             await UpdateEmployeeNameAsync(tenantId, postgresHost, postgresPort, employeeId, ownerName);
         }
 
-        _logger.LogInformation("Created default admin user for tenant {TenantId} with email {Email}. Default password: {Password}",
-            tenantId, email, DefaultAdminPassword);
+        // Never log the plaintext password.
+        _logger.LogInformation("Created default admin user for tenant {TenantId} with email {Email}", tenantId, email);
     }
 
     private async Task UpdateEmployeeNameAsync(string tenantId, string postgresHost, int postgresPort, Guid employeeId, string fullName)

--- a/backend/src/MechanicBuddy.Management.Api/Services/TenantProvisioningService.cs
+++ b/backend/src/MechanicBuddy.Management.Api/Services/TenantProvisioningService.cs
@@ -110,12 +110,16 @@ public class TenantProvisioningService : ITenantProvisioningService
             // Step 4: Create tenant database on shared PostgreSQL cluster
             AddLog(result, "Info", "CreateDatabase", "Creating database on shared PostgreSQL cluster");
             var ownerFullName = $"{request.OwnerFirstName} {request.OwnerLastName}".Trim();
+            // Per-tenant random admin password (never a shared default); surfaced
+            // in the result for out-of-band delivery to the owner.
+            var adminPassword = SecurePasswordGenerator.Generate();
             await _dbProvisioner.ProvisionTenantDatabaseAsync(
                 tenantId,
                 _options.FreeTier.PostgresHost,
                 _options.FreeTier.PostgresPort,
                 request.OwnerEmail,
-                ownerFullName);
+                ownerFullName,
+                adminPassword);
 
             AddLog(result, "Info", "CreateDatabase", "Database created successfully");
 
@@ -179,9 +183,9 @@ public class TenantProvisioningService : ITenantProvisioningService
             result.TenantUrl = $"https://{domain}";
             result.ApiUrl = $"https://{domain}/api";
 
-            // Step 8: Set admin credentials
-            result.AdminUsername = _options.DefaultAdmin.Username;
-            result.AdminPassword = _options.DefaultAdmin.Password;
+            // Step 8: Set admin credentials (the actual per-tenant random password)
+            result.AdminUsername = "admin";
+            result.AdminPassword = adminPassword;
 
             // Step 9: Set resource allocation (shared instance limits)
             var tierLimits = GetTierLimits(request.SubscriptionTier, request.ResourceOverrides);


### PR DESCRIPTION
## Summary
Closes #23 — **HIGH**: universal default tenant admin password.

The free-tier provisioner seeded every tenant's `admin` user with the same hardcoded `carcare` password (constant + precomputed BCrypt hash) and logged the plaintext. That's a universal, publicly-known credential for every freshly provisioned tenant.

## Changes
- **`SecurePasswordGenerator`** (new): cryptographically-random, complexity-guaranteed passwords via `RandomNumberGenerator`.
- Free-tier flow generates a per-tenant random password, passes it to `ProvisionTenantDatabaseAsync` (new optional `adminPassword` param), which BCrypt-hashes and inserts it. Removed the `carcare` constant + precomputed hash.
- Stopped logging the plaintext password.
- `result.AdminPassword` now carries the **actual** generated password (it previously returned a static, inaccurate `_options.DefaultAdmin.Password`), for out-of-band delivery to the owner. `must_change_password` stays `true`.

## Verification
- `dotnet build -c Release` (Management.Api) succeeds (0 errors).

## Related / follow-up
The **dedicated** (Helm) path seeds its admin via `DbUp/scripts/Script0001_CreateDefaultAdmin.cs` — that seed should get the same treatment (tracked alongside the original tracker item). This PR covers the free-tier `TenantDatabaseProvisioner` path named in #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)