### PR TITLE
fix(security): fail-fast on missing Postgres password (no default) (#28)

### DIFF
--- a/backend/src/MechanicBuddy.Management.Api/Infrastructure/KubernetesClient.cs
+++ b/backend/src/MechanicBuddy.Management.Api/Infrastructure/KubernetesClient.cs
@@ -56,7 +56,10 @@ public class KubernetesClient : IKubernetesClient
         _baseDomain = configuration["Cloudflare:BaseDomain"] ?? "mechanicbuddy.app";
         _postgresHost = configuration["Database:PostgresHost"] ?? "postgres";
         _postgresUser = configuration["Database:PostgresUser"] ?? "postgres";
-        _postgresPassword = configuration["Database:PostgresPassword"] ?? "postgres";
+        // No default for the password: fail fast rather than fall back to a
+        // well-known credential that would be serialized into tenant secrets.
+        _postgresPassword = configuration["Database:PostgresPassword"]
+            ?? throw new InvalidOperationException("Database:PostgresPassword is not configured");
 
         // Resend SMTP configuration for tenant instances
         _resendSmtpHost = configuration["Email:SmtpHost"] ?? "smtp.resend.com";

--- a/backend/src/MechanicBuddy.Management.Api/Infrastructure/TenantDatabaseProvisioner.cs
+++ b/backend/src/MechanicBuddy.Management.Api/Infrastructure/TenantDatabaseProvisioner.cs
@@ -32,7 +32,10 @@ public class TenantDatabaseProvisioner : ITenantDatabaseProvisioner
         _postgresHost = configuration["Database:PostgresHost"] ?? "postgres";
         _postgresPort = int.TryParse(configuration["Database:PostgresPort"], out var port) ? port : 5432;
         _postgresUser = configuration["Database:PostgresUser"] ?? "postgres";
-        _postgresPassword = configuration["Database:PostgresPassword"] ?? "postgres";
+        // No default for the password: fail fast rather than fall back to a
+        // well-known credential.
+        _postgresPassword = configuration["Database:PostgresPassword"]
+            ?? throw new InvalidOperationException("Database:PostgresPassword is not configured");
         // Tenant databases are named: mechanicbuddy-{tenantId}
         // Use dedicated config key to avoid confusion with management database
         _tenantDbPrefix = configuration["Database:TenantDatabasePrefix"] ?? "mechanicbuddy";


### PR DESCRIPTION
## Summary
Closes #28 (core) — **MEDIUM**: default `postgres/postgres` credentials.

`TenantDatabaseProvisioner` and `KubernetesClient` defaulted `Database:PostgresPassword` to `"postgres"` when unset. `KubernetesClient` serializes that connection into a per-tenant Kubernetes Secret, so a missing config value silently shipped a well-known superuser password into every tenant namespace.

## Change
- Both constructors now throw `InvalidOperationException` when `Database:PostgresPassword` is missing (no fallback). Host/user keep non-secret defaults.

## Verification
- `dotnet build -c Release` (Management.Api) succeeds (0 errors).

## Follow-up (noted in #28)
- The dev `appsettings.json`/`appsettings.Development.json` still contain `postgres/postgres` and a hardcoded dev JWT secret — those are dev-only; rotating/removing them and giving each tenant a least-privilege DB role (not the cluster superuser) are larger follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)