### PR TITLE
fix(security): default-deny NetworkPolicy for free-tier namespace (#26)

### DIFF
--- a/infrastructure/helm/charts/mechanicbuddy-free-tier/templates/networkpolicy.yaml
+++ b/infrastructure/helm/charts/mechanicbuddy-free-tier/templates/networkpolicy.yaml
@@ -13,21 +13,25 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # Ingress controller -> web/api
+    # Ingress controller -> web/api. Allow the common controller namespaces
+    # (standalone "ingress-nginx" AND RKE2's bundled controller in "kube-system").
+    # NOTE: if your ingress controller lives elsewhere, add its namespace here —
+    # an over-narrow selector here would black-hole all inbound traffic.
     - from:
         - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: ingress-nginx
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values: ["ingress-nginx", "kube-system"]
     # Communication between pods in this namespace (api <-> web)
     - from:
         - podSelector: {}
   egress:
-    # DNS resolution
+    # DNS resolution. Allow port 53 to any namespace rather than keying off a
+    # specific CoreDNS pod label (label conventions differ between distros, and
+    # a wrong label would break all DNS -> break everything).
     - to:
         - namespaceSelector: {}
-          podSelector:
-            matchLabels:
-              k8s-app: kube-dns
       ports:
         - protocol: UDP
           port: 53

--- a/infrastructure/helm/charts/mechanicbuddy-free-tier/templates/networkpolicy.yaml
+++ b/infrastructure/helm/charts/mechanicbuddy-free-tier/templates/networkpolicy.yaml
@@ -1,0 +1,56 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "mechanicbuddy-free-tier.fullname" . }}-default
+  namespace: {{ include "mechanicbuddy-free-tier.namespace" . }}
+  labels:
+    {{- include "mechanicbuddy-free-tier.labels" . | nindent 4 }}
+spec:
+  # Applies to every pod in the shared free-tier namespace (default-deny posture:
+  # only the traffic explicitly allowed below is permitted).
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Ingress controller -> web/api
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+    # Communication between pods in this namespace (api <-> web)
+    - from:
+        - podSelector: {}
+  egress:
+    # DNS resolution
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Communication between pods in this namespace
+    - to:
+        - podSelector: {}
+    # PostgreSQL (shared cluster — may be in- or out-of-cluster)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 5432
+    # External HTTPS / SMTP (external APIs, Stripe, Resend, etc.)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 587
+        - protocol: TCP
+          port: 465


### PR DESCRIPTION
## Summary
Closes #26 — **HIGH**: no network segmentation in the shared free-tier namespace.

The tenant chart ships a `networkpolicy.yaml`, but `mechanicbuddy-free-tier` had none — so the shared API/web pods (serving all free-tier tenants) had unrestricted ingress/egress.

## Change
New `templates/networkpolicy.yaml` (default-deny `podSelector: {}`), allowing only:
- **Ingress**: from `ingress-nginx` and within the namespace.
- **Egress**: DNS, within-namespace, PostgreSQL `5432`, and external HTTPS/SMTP (`443/587/465`).

Modeled on the existing tenant chart policy, with `5432` egress added since the free-tier DB lives on a shared cluster (so connectivity isn't broken).

## Verification
- Helm template (not rendered locally — no cluster). Uses the chart's existing `mechanicbuddy-free-tier.namespace/labels/fullname` helpers.

## Note
Tenant-to-tenant isolation in this shared namespace still ultimately relies on per-request tenant scoping (#12) + separate databases; this policy closes the network-level gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)