### PR TITLE
fix(security): JWT iss/aud validation + HS256 pin + UTF8 key (#29)

### DIFF
--- a/backend/src/MechanicBuddy.Core.Application/Authorization/AppJwtToken.cs
+++ b/backend/src/MechanicBuddy.Core.Application/Authorization/AppJwtToken.cs
@@ -23,7 +23,7 @@ namespace MechanicBuddy.Core.Application.Authorization
         {
             EnsureJwtSecret(options);
             var tokenHandler = new JwtSecurityTokenHandler();
-            var key = Encoding.ASCII.GetBytes(options.Secret);
+            var key = Encoding.UTF8.GetBytes(options.Secret);
             tokenHandler.ValidateToken(token, new TokenValidationParameters
             {
                 ValidateIssuerSigningKey = true,
@@ -46,7 +46,7 @@ namespace MechanicBuddy.Core.Application.Authorization
         {
             EnsureJwtSecret(options);
             var tokenHandler = new JwtSecurityTokenHandler();
-            var key = Encoding.ASCII.GetBytes(options.Secret);
+            var key = Encoding.UTF8.GetBytes(options.Secret);
 
             var subject = ((ClaimsIdentity)principal.Identity);
 

--- a/backend/src/MechanicBuddy.Core.Application/Extensions/DependencyInjection/AuthorizationExtensions.cs
+++ b/backend/src/MechanicBuddy.Core.Application/Extensions/DependencyInjection/AuthorizationExtensions.cs
@@ -27,10 +27,15 @@ namespace MechanicBuddy.Core.Application.Extensions.DependencyInjection
                 {
                     ValidateIssuerSigningKey = true,
                     IssuerSigningKey = new SymmetricSecurityKey(key),
-                    ValidateIssuer = false,
-                    ValidateAudience = false,
-                    // set clockskew to zero so tokens expire exactly at token expiration time (instead of 5 minutes later)
-                    ClockSkew = TimeSpan.Zero
+                    // Security: validate issuer/audience (must match AppJwtToken.Generate)
+                    // and pin the signing algorithm to HS256 to avoid algorithm confusion.
+                    ValidateIssuer = true,
+                    ValidIssuer = "MechanicBuddy",
+                    ValidateAudience = true,
+                    ValidAudience = "MechanicBuddy",
+                    ValidAlgorithms = new[] { SecurityAlgorithms.HmacSha256 },
+                    // small skew tolerance for distributed clocks
+                    ClockSkew = TimeSpan.FromSeconds(30)
                 };
 				options.Events = new JwtBearerEvents
 				{


### PR DESCRIPTION
## Summary
Closes #29 — **HIGH**: JWT validation gaps.

- The request-validation pipeline (`AuthorizationExtensions`) set `ValidateIssuer`/`ValidateAudience = false`, so any HS256 token signed with the shared secret was accepted regardless of issuer/audience — even though `AppJwtToken.Generate` stamps `iss`/`aud = "MechanicBuddy"`.
- `AppJwtToken` derived the key with `Encoding.ASCII` while the bearer pipeline uses `Encoding.UTF8` — a lossy mismatch for any non-ASCII secret.

## Changes
- Pipeline: `ValidateIssuer`/`ValidateAudience = true` with `ValidIssuer`/`ValidAudience = "MechanicBuddy"`; `ValidAlgorithms = [HS256]`; `ClockSkew = 30s`.
- `AppJwtToken`: `Encoding.ASCII` → `Encoding.UTF8` for both sign and validate.

## Verification
- `dotnet build -c Release` (Http.Api) succeeds (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)