### PR TITLE
fix: correctness cleanups (date filter, search, DeleteAccount) (#31)

### DIFF
--- a/backend/src/MechanicBuddy.Http.Api/Controllers/ProfileController.cs
+++ b/backend/src/MechanicBuddy.Http.Api/Controllers/ProfileController.cs
@@ -115,9 +115,11 @@ namespace MechanicBuddy.Http.Api.Controllers
         }
 
         [HttpDelete()]
-        public  IActionResult DeleteAccount()
+        public IActionResult DeleteAccount()
         {
-            return Ok();
+            // Account deletion is not implemented. Returning Ok() previously
+            // implied success while doing nothing; report Not Implemented instead.
+            return StatusCode(501, "Account deletion is not implemented yet.");
         }
     }
 

--- a/backend/src/MechanicBuddy.Http.Api/Controllers/QueryController.cs
+++ b/backend/src/MechanicBuddy.Http.Api/Controllers/QueryController.cs
@@ -44,9 +44,11 @@ namespace MechanicBuddy.Http.Api.Controllers
                         union all
                         select id, 'Employer' as resourcename,concat_ws(' ',firstname,lastname) as name,'tootaja' as controller from domain.employee 
                         ) results   
-	                        where to_tsvector(name) @@ to_tsquery(@arg)
+	                        where to_tsvector(name) @@ plainto_tsquery(@arg)
                         limit 10";
-            var arg = new WildcardTokens(searchText).ToString();
+            // plainto_tsquery accepts free text safely (parameterized). The old
+            // WildcardTokens.ToString() returned the type name, so search never worked.
+            var arg = searchText ?? string.Empty;
 
             var results = session.Connection.Query(sql, new { arg }).ToList();
 

--- a/backend/src/MechanicBuddy.Http.Api/Controllers/WorkController.cs
+++ b/backend/src/MechanicBuddy.Http.Api/Controllers/WorkController.cs
@@ -303,20 +303,20 @@ namespace MechanicBuddy.Http.Api.Controllers
           
             if (clientId  != null) query.Where($"w.clientid = '{clientId }'");
             if (vehicleId != null ) query.Where($"w.vehicleid = '{vehicleId}' ");
-            if (workForm is not null || workForm is not null)
-            { 
-                var dateRestriction = @" work.startedon {0})";
-                if (invoiceTo is null)
+            if (workForm is not null || workTo is not null)
+            {
+                var dateRestriction = @" work.startedon {0}";
+                if (workTo is null)
                 {
-                    dateRestriction = string.Format(dateRestriction, $" >= '{pgDate(invoiceFrom)}'");
+                    dateRestriction = string.Format(dateRestriction, $" >= '{pgDate(workForm)}'");
                 }
-                else if (invoiceFrom is null)
+                else if (workForm is null)
                 {
-                    dateRestriction = string.Format(dateRestriction, $" < '{pgDate(invoiceTo)}'");
+                    dateRestriction = string.Format(dateRestriction, $" < '{pgDate(workTo)}'");
                 }
                 else
                 {
-                    dateRestriction = string.Format(dateRestriction, $" between '{pgDate(invoiceFrom)}' and '{pgDate(invoiceTo)}' ");
+                    dateRestriction = string.Format(dateRestriction, $" between '{pgDate(workForm)}' and '{pgDate(workTo)}' ");
                 }
                 query.Where(dateRestriction);
             }


### PR DESCRIPTION
## Summary
Closes #31 — **LOW**: three correctness bugs found during review.

- **`WorkController.GetPage`**: the work-date filter condition was `workForm is not null || workForm is not null` (duplicate), and its body used the **invoice** dates plus a stray `)` that produced invalid SQL whenever a work date was supplied. Now uses `workForm`/`workTo` correctly against `work.startedon`.
- **`QueryController`**: `new WildcardTokens(searchText).ToString()` returned the type name (`...WildcardTokens`), so the global search never matched. Switched to `plainto_tsquery(@arg)` with the raw, parameterized search text (accepts free text safely).
- **`ProfileController.DeleteAccount`**: returned `Ok()` while doing nothing — now returns `501 Not Implemented` so it no longer implies a successful deletion.

## Verification
- `dotnet build -c Release` (Http.Api) succeeds (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)