### PR TITLE
fix(security): login hardening — no hash logging, account lockout, bcrypt $2b$ (#30)

### DIFF
--- a/backend/src/DbUp/scripts/Script0008_AddLoginLockout.sql
+++ b/backend/src/DbUp/scripts/Script0008_AddLoginLockout.sql
@@ -1,0 +1,8 @@
+-- =============================================================================
+-- Add login lockout tracking to the user table
+-- =============================================================================
+-- Tracks consecutive failed login attempts and a lockout expiry so the
+-- application can lock an account after too many failures (brute-force defence).
+
+ALTER TABLE public."user" ADD COLUMN IF NOT EXISTS failed_login_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE public."user" ADD COLUMN IF NOT EXISTS locked_until TIMESTAMPTZ NULL;

--- a/backend/src/MechanicBuddy.Core.Application/Authorization/PasswordHasher.cs
+++ b/backend/src/MechanicBuddy.Core.Application/Authorization/PasswordHasher.cs
@@ -13,7 +13,10 @@ namespace MechanicBuddy.Core.Application.Authorization
     {
         public static string getHash(string input)
         {
-            return BCrypt.Net.BCrypt.HashPassword(input);
+            // Use the modern $2b$ bcrypt revision (work factor 11). Verify still
+            // accepts existing $2a$ hashes, so this is backwards compatible.
+            var salt = BCrypt.Net.BCrypt.GenerateSalt(11, 'b');
+            return BCrypt.Net.BCrypt.HashPassword(input, salt);
         }
 
         // Verify a hash against a string.

--- a/backend/src/MechanicBuddy.Http.Api/Controllers/UsersController.cs
+++ b/backend/src/MechanicBuddy.Http.Api/Controllers/UsersController.cs
@@ -82,6 +82,14 @@ All authenticated user operations; decorate the whole class with [TenantRateLimi
             this.dbOptions = dbOptions.Value;
         }
 
+        // Login lockout / password state read from public.user (Dapper maps by column name).
+        private sealed class LoginStateDto
+        {
+            public int failed_login_attempts { get; set; }
+            public DateTime? locked_until { get; set; }
+            public bool? must_change_password { get; set; }
+        }
+
 
         [AllowAnonymous, LimitRequests(MaxRequests = 10, TimeWindow = 60)]
         [HttpPost("authenticate")]
@@ -105,44 +113,75 @@ All authenticated user operations; decorate the whole class with [TenantRateLimi
                 return Unauthorized();
             }
 
-            if (!PasswordHasher.verifyHash(model.Password, user.Password))
-            {
-                // Never log password hash material.
-                logger.LogInformation("Authentication failure: {user} - invalid password", model.Username);
-                await Task.Delay(TimeSpan.FromSeconds(SecondsToWaitOnFailedLogonAttempt));
-                return Unauthorized();
-            }
+            const int MaxFailedAttempts = 5;
+            const int LockoutMinutes = 15;
 
-            // Check if user must change password
-            var mustChangePassword = false;
-
-            // Check if using default password hash
             var isUsingDefaultPassword = user.Password == DefaultPasswordHash;
 
-            // Also check the must_change_password field from database
             var databaseName = dbOptions.MultiTenancy?.Enabled == true
                 ? new MultiTenancyDbName(dbOptions, DbKind.Tenancy)
                 : dbOptions.Name;
 
-            var connectionBuilder = new Npgsql.NpgsqlConnectionStringBuilder
+            var connectionString = new Npgsql.NpgsqlConnectionStringBuilder
             {
                 Host = dbOptions.Host,
                 Port = dbOptions.Port,
                 Username = dbOptions.UserId,
                 Password = dbOptions.Password,
                 Database = databaseName
-            };
+            }.ToString();
 
-            using (var connection = new Npgsql.NpgsqlConnection(connectionBuilder.ToString()))
+            var userKey = new { TenantName = user.Id.TenantName, EmployeeId = user.Id.EmployeeId };
+            bool mustChangePassword;
+
+            await using (var connection = new Npgsql.NpgsqlConnection(connectionString))
             {
                 await connection.OpenAsync();
-                var result = await connection.QuerySingleOrDefaultAsync<bool?>(
-                    @"SELECT must_change_password
+
+                var state = await connection.QuerySingleOrDefaultAsync<LoginStateDto>(
+                    @"SELECT failed_login_attempts, locked_until, must_change_password
                       FROM public.user
                       WHERE tenantname = @TenantName AND employeeid = @EmployeeId",
-                    new { TenantName = user.Id.TenantName, EmployeeId = user.Id.EmployeeId });
+                    userKey);
 
-                var mustChangePasswordFromDb = result ?? false;
+                var failedAttempts = state?.failed_login_attempts ?? 0;
+                var lockedUntil = state?.locked_until;
+                var mustChangePasswordFromDb = state?.must_change_password ?? false;
+
+                // Account lockout: reject while locked, without revealing whether the password was right.
+                if (lockedUntil.HasValue && lockedUntil.Value.ToUniversalTime() > DateTime.UtcNow)
+                {
+                    logger.LogInformation("Authentication blocked: {user} - account temporarily locked", model.Username);
+                    await Task.Delay(TimeSpan.FromSeconds(SecondsToWaitOnFailedLogonAttempt));
+                    return Unauthorized();
+                }
+
+                if (!PasswordHasher.verifyHash(model.Password, user.Password))
+                {
+                    var newCount = failedAttempts + 1;
+                    DateTime? newLock = newCount >= MaxFailedAttempts
+                        ? DateTime.UtcNow.AddMinutes(LockoutMinutes)
+                        : null;
+                    await connection.ExecuteAsync(
+                        @"UPDATE public.user SET failed_login_attempts = @Count, locked_until = @Locked
+                          WHERE tenantname = @TenantName AND employeeid = @EmployeeId",
+                        new { Count = newCount, Locked = newLock, user.Id.TenantName, user.Id.EmployeeId });
+
+                    // Never log password hash material.
+                    logger.LogInformation("Authentication failure: {user} - invalid password", model.Username);
+                    await Task.Delay(TimeSpan.FromSeconds(SecondsToWaitOnFailedLogonAttempt));
+                    return Unauthorized();
+                }
+
+                // Successful login: clear any failed-attempt / lock state.
+                if (failedAttempts != 0 || lockedUntil.HasValue)
+                {
+                    await connection.ExecuteAsync(
+                        @"UPDATE public.user SET failed_login_attempts = 0, locked_until = NULL
+                          WHERE tenantname = @TenantName AND employeeid = @EmployeeId",
+                        userKey);
+                }
+
                 mustChangePassword = isUsingDefaultPassword || mustChangePasswordFromDb;
             }
 

--- a/backend/src/MechanicBuddy.Http.Api/Controllers/UsersController.cs
+++ b/backend/src/MechanicBuddy.Http.Api/Controllers/UsersController.cs
@@ -107,7 +107,8 @@ All authenticated user operations; decorate the whole class with [TenantRateLimi
 
             if (!PasswordHasher.verifyHash(model.Password, user.Password))
             {
-                logger.LogInformation("Authentication failure: {user} - Password verification failed (hash: {hash})", model.Username, user.Password?.Substring(0, 20) + "...");
+                // Never log password hash material.
+                logger.LogInformation("Authentication failure: {user} - invalid password", model.Username);
                 await Task.Delay(TimeSpan.FromSeconds(SecondsToWaitOnFailedLogonAttempt));
                 return Unauthorized();
             }


### PR DESCRIPTION
## Summary
Closes #30 — login hardening.

## Changes
- **Stop logging hash material**: failed-password logging no longer includes any of the stored BCrypt hash (the original tracker claim had regressed).
- **Account lockout** (persistent, cross-replica): `Script0008` adds `failed_login_attempts` + `locked_until` to `public.user`. `Authenticate` rejects logins while locked (uniform `Unauthorized` + delay, no password-validity leak), increments the counter on each bad password, locks for **15 min after 5** consecutive failures, and resets on success.
- **BCrypt `$2b$`**: `PasswordHasher.getHash` now uses `GenerateSalt(11, 'b')`; `Verify` still accepts existing `$2a$` hashes (backwards compatible).

## Verification
- `dotnet build -c Release` for Http.Api and Core.Application succeed (0 errors).
- Migration follows the existing `public.user` `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` pattern (Script0006) and is embedded/run by DbUp like the other `*.sql` scripts.

## Out of scope (separate LOW tracker items)
MFA (#36) and password-history (#35) remain as their own items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)