### PR TITLE
fix(security): provisioner RBAC hardening — drop secrets:list, scope namespace ops (#24)

### DIFF
--- a/backend/src/MechanicBuddy.Management.Api/Services/KubernetesClientService.cs
+++ b/backend/src/MechanicBuddy.Management.Api/Services/KubernetesClientService.cs
@@ -20,11 +20,29 @@ public class KubernetesClientService : IKubernetesClientService
         _logger = logger;
     }
 
+    // Security: the provisioner may only ever create/delete tenant namespaces.
+    // This guards against a crafted/unexpected namespace name being used to
+    // create or (far worse) delete a platform namespace such as
+    // mechanicbuddy-system or kube-system.
+    private static readonly string[] ManagedNamespacePrefixes = { "mb-", "tenant-" };
+
+    private static bool IsManagedTenantNamespace(string namespaceName) =>
+        !string.IsNullOrWhiteSpace(namespaceName)
+        && namespaceName.Length <= 63
+        && ManagedNamespacePrefixes.Any(p => namespaceName.StartsWith(p, StringComparison.Ordinal))
+        && System.Text.RegularExpressions.Regex.IsMatch(namespaceName, "^[a-z0-9-]+$");
+
     public async Task<bool> CreateNamespaceAsync(
         string namespaceName,
         Dictionary<string, string>? labels = null,
         CancellationToken cancellationToken = default)
     {
+        if (!IsManagedTenantNamespace(namespaceName))
+        {
+            _logger.LogError("Refusing to create non-tenant namespace {Namespace}", namespaceName);
+            return false;
+        }
+
         try
         {
             _logger.LogInformation("Creating namespace {Namespace}", namespaceName);
@@ -58,6 +76,12 @@ public class KubernetesClientService : IKubernetesClientService
         string namespaceName,
         CancellationToken cancellationToken = default)
     {
+        if (!IsManagedTenantNamespace(namespaceName))
+        {
+            _logger.LogError("Refusing to delete non-tenant namespace {Namespace}", namespaceName);
+            return false;
+        }
+
         try
         {
             _logger.LogInformation("Deleting namespace {Namespace}", namespaceName);

--- a/infrastructure/helm/charts/mechanicbuddy-system/templates/rbac.yaml
+++ b/infrastructure/helm/charts/mechanicbuddy-system/templates/rbac.yaml
@@ -25,10 +25,15 @@ rules:
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "create", "delete", "patch"]
-  # Secret management
+  # Secret management.
+  # NOTE: "list" is intentionally omitted — the provisioner only reads secrets
+  # by name (ReadNamespacedSecret), so cluster-wide secret *enumeration* is not
+  # needed and would let a compromised pod exfiltrate every secret in the
+  # cluster. Scoping the remaining verbs to specific namespaces via per-tenant
+  # Roles is a further hardening step (tracked in the issue).
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list", "create", "delete", "patch"]
+    verbs: ["get", "create", "delete", "patch"]
   # ConfigMap management
   - apiGroups: [""]
     resources: ["configmaps"]


### PR DESCRIPTION
## Summary
Closes #24 — reduce the tenant-provisioner's privilege/blast-radius.

### 1. Drop cluster-wide `secrets: list`
The ClusterRole granted cluster-wide `secrets: [get, list, …]`. `list` lets a compromised management-api pod **enumerate and read every Secret in the cluster**. The code only ever calls `ReadNamespacedSecret` (get by name) — confirmed no `List*Secret` usage — so `list` is removed (get/create/delete/patch kept).

### 2. Restrict namespace operations to managed namespaces (code guard)
`KubernetesClientService.Create/DeleteNamespaceAsync` took a full namespace string from the provisioning flow with no validation. A crafted/unexpected value could create or (worse) **delete a platform namespace** like `mechanicbuddy-system` or `kube-system`. Both now require the name to match a managed tenant pattern (`mb-*` / `tenant-*`, valid DNS label) and refuse otherwise.

## Why not split into per-tenant namespaced Roles?
Evaluated and intentionally not pursued: a provisioning controller that manages a *dynamic* set of namespaces legitimately needs a ClusterRole. Replacing it with per-namespace Roles would require the controller to create `roles`/`rolebindings` cluster-wide — itself escalation-capable — without a clear security win, and can't be validated without a live cluster. `serviceaccounts: create` is **kept** because the tenant Helm chart (`templates/serviceaccount.yaml`) needs it during `helm install`.

## Verification
- `dotnet build -c Release` (Management.Api) succeeds (0 errors).
- Confirmed provisioner uses only `ReadNamespacedSecret`; tenant chart creates a ServiceAccount (so that grant is required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)