### PR TITLE
fix(security): pin GitHub Actions + image tags (#27)

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -72,7 +72,7 @@ jobs:
              src/MechanicBuddy.Http.Api/appsettings.Secrets.json
 
       - name: Populate Secrets
-        uses: microsoft/variable-substitution@v1
+        uses: microsoft/variable-substitution@6287962da9e5b6e68778dc51e840caa03ca84495 # v1
         with:
           files: "backend/src/MechanicBuddy.Http.Api/appsettings.Secrets.json"
         env:
@@ -107,7 +107,7 @@ jobs:
       # ---------------------------------------------------------------------
       #  Deploy ------------------------------------------------------------------
       - name: Deploy DbUp with rsync
-        uses: burnett01/rsync-deployments@7.0.2
+        uses: burnett01/rsync-deployments@fcf16a05b8650e3704a3871139dce6dde00aa472 # 7.0.2
         with:
           switches: -avzr --delete
           path: backend/dist/dbup
@@ -117,7 +117,7 @@ jobs:
           remote_key: ${{ inputs.ssh-key }}
 
       - name: Deploy API with rsync
-        uses: burnett01/rsync-deployments@7.0.2
+        uses: burnett01/rsync-deployments@fcf16a05b8650e3704a3871139dce6dde00aa472 # 7.0.2
         with:
           switches: -avzr --delete --exclude="MechanicBuddy.Http.Api.staticwebassets.runtime.json"
           path: backend/dist/mechanicbuddy
@@ -127,7 +127,7 @@ jobs:
           remote_key: ${{ inputs.ssh-key }}
 
       - name: Run DbUp migrations and reload API
-        uses: appleboy/ssh-action@v1.2.1
+        uses: appleboy/ssh-action@8faa84277b88b6cd1455986f459aa66cf72bc8a3 # v1.2.1
         with:
           host: ${{ inputs.application-host }}
           username: ${{ inputs.application-host-user }}

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -75,7 +75,7 @@ jobs:
       run: rm -rf src
 
     - name: Deploy with rsync
-      uses: burnett01/rsync-deployments@7.0.2
+      uses: burnett01/rsync-deployments@fcf16a05b8650e3704a3871139dce6dde00aa472 # 7.0.2
       with:
         switches: -avzr --delete  --exclude=".git" --exclude=".github" --exclude=".vscode" --exclude="node_modules"
         path: ./frontend/
@@ -85,7 +85,7 @@ jobs:
         remote_key: ${{ inputs.ssh-key }}
 
     - name: Reloading mechanicbuddy-app pm2 process
-      uses: appleboy/ssh-action@v1.2.1
+      uses: appleboy/ssh-action@8faa84277b88b6cd1455986f459aa66cf72bc8a3 # v1.2.1
       with:
         host: ${{ inputs.application-host }}
         username: ${{ inputs.application-host-user }}

--- a/.github/workflows/gitops-deploy.yml
+++ b/.github/workflows/gitops-deploy.yml
@@ -142,7 +142,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Kustomize
-        uses: imranismail/setup-kustomize@v2
+        uses: imranismail/setup-kustomize@2ba527d4d055ab63514ba50a99456fc35684947f # v2
 
       - name: Determine environment
         id: env

--- a/infrastructure/helm/charts/mechanicbuddy-free-tier/values.yaml
+++ b/infrastructure/helm/charts/mechanicbuddy-free-tier/values.yaml
@@ -45,7 +45,7 @@ api:
   # Container image
   image:
     repository: "ghcr.io/d4m13n-d3v/mechanicbuddy-api"
-    tag: "latest"
+    tag: "f44547f"  # pin to an immutable image tag; override per release
     pullPolicy: "IfNotPresent"
   # Service port
   port: 15567
@@ -73,7 +73,7 @@ web:
   # Container image
   image:
     repository: "ghcr.io/d4m13n-d3v/mechanicbuddy-web"
-    tag: "latest"
+    tag: "f44547f"  # pin to an immutable image tag; override per release
     pullPolicy: "IfNotPresent"
   # Service port
   port: 3000
@@ -97,7 +97,7 @@ migrations:
   # Migration job image
   image:
     repository: "ghcr.io/d4m13n-d3v/mechanicbuddy-dbup"
-    tag: "latest"
+    tag: "f44547f"  # pin to an immutable image tag; override per release
     pullPolicy: "IfNotPresent"
   # Timeout for migration job
   timeout: 300

--- a/infrastructure/helm/charts/mechanicbuddy-system/templates/cronjobs.yaml
+++ b/infrastructure/helm/charts/mechanicbuddy-system/templates/cronjobs.yaml
@@ -74,7 +74,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: subscription-expiry
-              image: curlimages/curl:latest
+              image: curlimages/curl:8.11.1
               command:
                 - /bin/sh
                 - -c

--- a/infrastructure/helm/charts/mechanicbuddy-system/values.yaml
+++ b/infrastructure/helm/charts/mechanicbuddy-system/values.yaml
@@ -42,7 +42,7 @@ managementApi:
   replicas: 2
   image:
     repository: "ghcr.io/mechanicbuddy/management-api"
-    tag: "latest"
+    tag: "f44547f"  # pin to an immutable image tag; override per release
     pullPolicy: "IfNotPresent"
   port: 15568
   resources:
@@ -65,7 +65,7 @@ portal:
   replicas: 2
   image:
     repository: "ghcr.io/mechanicbuddy/management-portal"
-    tag: "latest"
+    tag: "f44547f"  # pin to an immutable image tag; override per release
     pullPolicy: "IfNotPresent"
   port: 3001
   resources:
@@ -151,7 +151,7 @@ demoCleanup:
   schedule: "0 3 * * *"  # Daily at 3 AM
   image:
     repository: "ghcr.io/mechanicbuddy/demo-cleanup"
-    tag: "latest"
+    tag: "f44547f"  # pin to an immutable image tag; override per release
 
 # -----------------------------------------------------------------------------
 # Subscription Expiry Check (CronJob)

--- a/infrastructure/helm/charts/mechanicbuddy-tenant/values.yaml
+++ b/infrastructure/helm/charts/mechanicbuddy-tenant/values.yaml
@@ -75,7 +75,7 @@ api:
   # Container image
   image:
     repository: "ghcr.io/mechanicbuddy/api"
-    tag: "latest"
+    tag: "f44547f"  # pin to an immutable image tag; override per release
     pullPolicy: "IfNotPresent"
   # Service port
   port: 15567
@@ -103,7 +103,7 @@ web:
   # Container image
   image:
     repository: "ghcr.io/mechanicbuddy/web"
-    tag: "latest"
+    tag: "f44547f"  # pin to an immutable image tag; override per release
     pullPolicy: "IfNotPresent"
   # Service port
   port: 3000
@@ -127,7 +127,7 @@ migrations:
   # Migration job image
   image:
     repository: "ghcr.io/mechanicbuddy/dbup"
-    tag: "latest"
+    tag: "f44547f"  # pin to an immutable image tag; override per release
     pullPolicy: "IfNotPresent"
   # Timeout for migration job
   timeout: 300


### PR DESCRIPTION
## Summary
Closes #27 — supply-chain pinning (both halves).

### GitHub Actions → commit SHAs
Third-party actions (several receive the prod SSH key) pinned to immutable SHAs, tag in a trailing comment:
| Action | Tag | SHA |
|---|---|---|
| burnett01/rsync-deployments | 7.0.2 | `fcf16a0…` |
| appleboy/ssh-action | v1.2.1 | `8faa842…` |
| microsoft/variable-substitution | v1 | `6287962…` |
| imranismail/setup-kustomize | v2 | `2ba527d…` |

### Image tags → pinned
- `mechanicbuddy-{tenant,free-tier,system}/values.yaml`: `tag: "latest"` → `tag: "f44547f"` (the immutable tag already used by `values-production.yaml`; override per release).
- `cronjobs.yaml`: `curlimages/curl:latest` → `curlimages/curl:8.11.1`.

README example snippets still show `latest` (documentation only). `actions/*` first-party actions left on major tags.

## Verification
- Action SHAs resolved live from each repo's tag refs.
- All workflows + chart `values.yaml` validated with `yaml.safe_load`; no functional `latest` tags remain in the charts.

## Merge note
Lightly overlaps #35 on the build workflows (different lines: `uses:` here vs `secrets:`/`deploy:` there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)