### PR TITLE
fix(work): correct offer column name to match DB schema

### DIFF
--- a/backend/src/MechanicBuddy.Core.Application/Services/DemoSetupService.cs
+++ b/backend/src/MechanicBuddy.Core.Application/Services/DemoSetupService.cs
@@ -232,7 +232,7 @@ namespace MechanicBuddy.Core.Application.Services
             // Create an offer
             var offerId = Guid.NewGuid();
             await connection.ExecuteAsync(@"
-        INSERT INTO domain.offer(id, workid, ordernr, notes, isvehilelesonestimate, startedon, starterid)
+        INSERT INTO domain.offer(id, workid, ordernr, notes, isvehilelinesonestimate, startedon, starterid)
         VALUES (@Id, @WorkId, 1, 'Demo offer', true, CURRENT_TIMESTAMP, @StarterId)",
                 new { Id = offerId, WorkId = workId, StarterId = adminEmployeeId });
 

--- a/backend/src/MechanicBuddy.Core.Persistence.Postgres/ClassMappings.cs
+++ b/backend/src/MechanicBuddy.Core.Persistence.Postgres/ClassMappings.cs
@@ -262,7 +262,7 @@ namespace MechanicBuddy.Core.Persistence.Postgres.Repositories
             References(x=>x.Work, "workid").Access.LowerCaseField();
             Map(x => x.OrderNr).Column("ordernr");
             Map(x => x.Notes).Column("notes");
-            Map(x => x.IsVehicleLinesOnEstimate).Column("isvehilelesonestimate");
+            Map(x => x.IsVehicleLinesOnEstimate).Column("isvehilelinesonestimate");
             Map(x => x.AcceptedOn).Column("acceptedon").CustomType<UtcDateType>();//.HasConversion<DateTimeUtcConverter>();
             Map(x => x.StartedOn).Column("startedon").CustomType<UtcDateType>();//.HasConversion<DateTimeUtcConverter>();
             References(x => x.Starter).Column("starterid").Access.BackingField();

--- a/backend/src/MechanicBuddy.Http.Api/Controllers/WorkController.cs
+++ b/backend/src/MechanicBuddy.Http.Api/Controllers/WorkController.cs
@@ -102,7 +102,7 @@ namespace MechanicBuddy.Http.Api.Controllers
 										   startedon,
 										   starterId,'offer' as name,
 										   notes,
-										   isvehilelesonestimate as isvehiclelinesonpricing,
+										   isvehilelinesonestimate as isvehiclelinesonpricing,
 										   (offer.notes IS NULL OR length(offer.notes)=0) 
 										    and not   exists(select * from domain.productoffered where offerid = offer.id)
 											and not exists(select * from domain.serviceoffered where offerid = offer.id) AS isempty 


### PR DESCRIPTION
## Problem

Adding, editing, or viewing a work order on the demo returned **500 Internal Server Error**:

> `could not initialize a collection: MechanicBuddy.Core.Domain.Work.Offers … SELECT … offers0_.isvehilelesonestimate … FROM domain.offer`

Reproduced live: submitting the new-work form silently redirects to `/error?code=500`.

## Root cause

Column-name mismatch between code and database. The `domain.offer` table is created by the schema as `IsVehileLinesOnEstimate` → Postgres stores it lowercased as **`isvehilelinesonestimate`**. Three code references used **`isvehilelesonestimate`** (missing the "in"), a column that doesn't exist, so any operation touching a work's `Offers` collection threw.

Commit `ecd15d5` ("Fix work details column typo") introduced part of this by changing the correct name to the broken one; the NHibernate mapping was independently wrong as well.

## Fix

Aligned all three references to the actual DB column `isvehilelinesonestimate`:

- `ClassMappings.cs` — NHibernate `Offer` mapping (the source of the "could not initialize a collection" error)
- `WorkController.cs` — activities SQL query
- `DemoSetupService.cs` — demo-seed INSERT

**No DB migration required** — the existing database already has the correct column; the code was out of sync. Backend solution builds clean. Backend-only change (`[skip-frontend]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)